### PR TITLE
belindas-closet_3 _21_ create-pr-template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,25 @@
+### **Pull requests should follow a common structure for organizational purposes and quick readability.** 
+
+## **So what format should we follow?**
+
+# **When first submitting your pull request, make sure to assign it on github to your team members who will be responsible for validating your pull request and make sure there are no merge conflicts.**
+
+![Assignees](https://github.com/SeattleColleges/nsc-events-nextjs/assets/37163331/d0d2795b-32fd-447f-8d66-252f7dba3083)
+
+# **After assigning to a particular member set, we can then assign it to a proper project if you are working across multiple repos. This is especially important for the above reason, and is a fantastic way to organize your pull requests without mixing up where they are intended to go.**
+
+![Projects](https://github.com/SeattleColleges/nsc-events-nextjs/assets/37163331/b5f5a5f8-d375-4b8a-818f-f4ae9c33df9d)
+
+# **We can also assign a label to the pull request. This lets your PM/PO/ etc know what this pull request applies to. This makes assessing what we're looking for very quick and easy as a Project Manager, or other leader within the team.**
+
+![Labels](https://github.com/SeattleColleges/nsc-events-nextjs/assets/37163331/86e27abd-d119-4194-bb79-a97fe7eb5fdd)
+
+# **When submitting your pull request, be descriptive in both your topic name (IntelliJ Configuration(s)) and also assign it to a numbered issue. In this case, we've assigned this #12, because at the time of creation, there were 11 issues, and this was the logical next number to assign it to.**
+
+![PullComment](https://github.com/SeattleColleges/nsc-events-nextjs/assets/37163331/907d72fc-b85f-47c8-bfd5-6187e8d61d0d)
+
+# **When submitting a comment for a pull request, please label your pull request as a solution to another issue.**
+
+For example, reference the below image, and what I have put into the comment that will resolve our number 12 issue of no .idea file that's ignored in our .gitignore file.
+
+![ResolvesComment](https://github.com/SeattleColleges/nsc-events-nextjs/assets/37163331/ed24c121-5af0-465b-9ad9-d7999ea9250f)


### PR DESCRIPTION
This resolves #21.

Including this file will automatically show this pull request template when creating a pull request.

I attempted to create it in docs folder to mock what is on the NSC sister repo but was having issues (probably because we have a docs that is not a folder?). The only other change that does not align completely with the sister repo is that I highlighted the last point as important/required instead of as "extra information."