### PR TITLE
belinda-nextjs-01-130-modify-fronend-port

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 8080",
     "build": "next build",
     "start": "next start -p 8080",
     "lint": "next lint",


### PR DESCRIPTION
Resolves #130 

Modify the front-end port (in dev mode) from default 3000 to 8080 in the package.json file:
![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/2d08e53f-f728-4163-80c5-63b6542d09fe)

The result after modifying the port in package.json and the .env file:

![mobile-2-ezgif com-speed](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/c8960db8-8270-4c19-bed2-c589ba4b753b)
