### PR TITLE
belindas-closet-nextjs-1-145-remove-and-add-links-to-nav-bar

### DIFF
--- a/components/AuthProfileMenu.tsx
+++ b/components/AuthProfileMenu.tsx
@@ -10,7 +10,7 @@ export default function AuthProfileMenu() {
     return (
         <div className="flex items-center justify-center">
             <a href="/profile" className="hover:underline">Hi {data?.user?.name},</a>
-            <a className="ml-3 hover:underline" href="/product-page">add product</a>
+            <a className="ml-3 hover:underline" href="/product-page">Add product</a>
             <button className="ml-3 hover:underline" onClick={() => signOut({ callbackUrl: "/" })}>Sign out</button>
         </div>
     );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -10,8 +10,8 @@ export default function Navbar() {
     <nav className="flex items-center max-w-screen-lg mx-auto px-5 py-2 shadow-md justify-between mt-2 mb-2 rounded">
       <a href="/"><Image src={logo} alt="logo" width={40} height={40}/></a>
       <Link href="/">Home</Link>
-      <Link href="/auth/sign-in">sign in</Link>
-      <Link href="/auth/sign-up">sign up</Link>
+      <Link href="/auth/sign-in">Sign in</Link>
+      <Link href="/donation-info">Donation Info</Link>
       <AuthProfileMenu />      
     </nav>
   )


### PR DESCRIPTION
Resolves #145 

This PR:
- Removes the sign up link from the nav bar
- Adds a donation info page link to the nav bar (the link is a placeholder since the donation page doesn't exist yet)

<img width="700" alt="Screenshot 2024-01-18 210429" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/389d504f-80af-4ff4-9a20-9c50bd0c6411">

Relates to #142 