### PR TITLE
belindas-closet-nextjs_1_176_creators-page-placeholder

### DIFF
--- a/app/creator-page/page.tsx
+++ b/app/creator-page/page.tsx
@@ -1,0 +1,11 @@
+const Creator = () => {
+    // Temporary boilerplate code to make it compile
+    return (
+        <div className="flex flex-col items-center justify-center min-h-screen">
+            <h1>Placeholder creators page.</h1>
+            <p>Place holder text to fill in the space.</p>
+        </div>
+    );
+};
+
+export default Creator;


### PR DESCRIPTION
resolves: #176 
I have added a placeholder creator's page where there is currently nothing in it other than just placeholder text. Currently, there is no sign-in function to route any creators to the page yet as I'm awaiting further progress on the log-in implementation.
