### PR TITLE
belindas-closet-nextjs-2-180-added-buttons-to-creator-page

### DIFF
--- a/app/creator-page/page.tsx
+++ b/app/creator-page/page.tsx
@@ -1,7 +1,25 @@
+import styles from "../home.module.css";
+
 const Creator = () => {
     // Temporary boilerplate code to make it compile
     return (
         <div className="flex flex-col items-center justify-center min-h-screen">
+       
+        <div >
+            <div className={styles.loginButton}>
+                <a href="/">
+                <button>All Products</button>
+                </a>
+            </div>
+            
+            <div className={styles.loginButton}>
+                <a href="/add-product-page">
+                <button>Add Products</button>
+                </a>
+            </div>
+
+        </div>
+
             <h1>Placeholder creators page.</h1>
             <p>Place holder text to fill in the space.</p>
         </div>


### PR DESCRIPTION
As a developer, I wanted to adda couple of buttons to the creator's page that currently links to the add products and the home page where all the product categories are currently. I have set the styling currently to match the nextjs version and not the Android version just to make things consistent for now but I can convert to Android's styling if need be before merging.

Still no role authorization as I can meet with Tin later about implementing it.












