### PR TITLE
belindas-closet-nextjs_2_196_link-product-categories-in-dropdown

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -26,15 +26,15 @@ export default function Navbar() {
         {showCategories && (
           <div className="absolute bg-black p-3 rounded-b shadow-md text-center left-1/2 transform -translate-x-1/2 top-12">
             <ul>
-              <li className="p-2"><Link href="">Shirts</Link></li>
-              <li className="p-2"><Link href="">Shoes</Link></li>
-              <li className="p-2"><Link href="">Pants</Link></li>
-              <li className="p-2"><Link href="">Skirts</Link></li>
-              <li className="p-2"><Link href="">Suits</Link></li>
-              <li className="p-2"><Link href="">Dress</Link></li>
-              <li className="p-2"><Link href="">Casual Wear</Link></li>
-              <li className="p-2"><Link href="">Accessories</Link></li>
-              <li className="p-2"><Link href="">Jackets and Blazers</Link></li>
+              <li className="p-2"><Link href="/category-page/Shirts" onClick={toggleCategoriesMenu}>Shirts</Link></li>
+              <li className="p-2"><Link href="/category-page/Shoes" onClick={toggleCategoriesMenu}>Shoes</Link></li>
+              <li className="p-2"><Link href="/category-page/Pants" onClick={toggleCategoriesMenu}>Pants</Link></li>
+              <li className="p-2"><Link href="/category-page/Skirts" onClick={toggleCategoriesMenu}>Skirts</Link></li>
+              <li className="p-2"><Link href="/category-page/Suits" onClick={toggleCategoriesMenu}>Suits</Link></li>
+              <li className="p-2"><Link href="/category-page/Dress" onClick={toggleCategoriesMenu}>Dress</Link></li>
+              <li className="p-2"><Link href="/category-page/Casual Wear" onClick={toggleCategoriesMenu}>Casual Wear</Link></li>
+              <li className="p-2"><Link href="/category-page/Accessories" onClick={toggleCategoriesMenu}>Accessories</Link></li>
+              <li className="p-2"><Link href="/category-page/Jacket%2FBlazer" onClick={toggleCategoriesMenu}>Jackets and Blazers</Link></li>
             </ul>
           </div>
         )}


### PR DESCRIPTION
Resolves #196 

This PR adds action to the product categories in the product dropdown, each of them routing to their own category page. For consistency, I used the same links as the product category cards on the home page. I also made the drop-down menu close after you click on a category.

<img width="700" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/30b3368a-f13d-4e98-ab87-4b808baae622">

Related to #195 

