### PR TITLE
Belindas-closet-nextjs-3-214-Signup-Page

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -14,6 +14,7 @@ const SignUp = () => {
     email: "",
     password: "",
     confirmPassword: "",
+    role: "creator",
   });
   // Set initial state for errors
     const [errors, setErrors] = useState({
@@ -51,7 +52,8 @@ const SignUp = () => {
   }
   
     // send request to backend api then log the response
-    const res = await fetch("/api/auth/users", {
+    // hardwired link for local development, change port if needed
+    const res = await fetch("http://localhost:3000/api/auth/signup", {
       method: "POST",
       body: JSON.stringify(userInfo),
       headers: {
@@ -64,6 +66,10 @@ const SignUp = () => {
     } catch (error) {
       console.error("Error parson JSON response:", error);
     }
+
+    // temporary alert for testing
+    if (res.ok) alert('sign up was successful')
+
   };
 
   return (
@@ -158,6 +164,7 @@ const SignUp = () => {
       </form>
     </div>
   );
+  
 };
 
 export default SignUp;


### PR DESCRIPTION
Resolves #214 
Changed sign-up page to send a POST request to the Nest.js backend. 
To test:
local nest.js server with MongoDB need to be working, if port is different from 3000, it needs to be changed in /belindas-closet-nextjs/app/auth/sign-up/page.tsx to the one your server is using. 
Go to signup page http://localhost:8080/auth/sign-up (again, check your ports), enter the required data and click the Sign Up button, if it is successful, you'll see the alert and the response from the API with the token like this:

![Screenshot_20240215_112020a](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/17448320/bbffc08d-29ec-4d05-94df-d0da4379f856)

Also there should be the new entry for the new user you signed up in the Nest database:

![Screenshot_20240215_112250](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/17448320/8a3a9303-6e7d-481f-bccb-509b1bc88784)

 