### PR TITLE
belinda-nextjs-03-211-general-page-styling-to-MUI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,10 @@ import './globals.css';
 import { Inter } from 'next/font/google';
 import Navbar from '@/components/Navbar';
 import SessionProvider from '@/components/SessionProvider';
-import { ThemeProvider } from '@mui/material/styles';
+import { ThemeProvider } from "@mui/material/styles";
 import theme from './theme/theme';
+import CssBaseline from "@mui/material/CssBaseline";
+
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -21,13 +23,14 @@ export default function RootLayout({
 }) {
   return (
     <ThemeProvider theme={theme}>
-    <html lang="en">
-      <body className={inter.className}>
-        <SessionProvider>
-          <Navbar/>{children}
-        </SessionProvider>
-      </body>
-    </html>
+      <CssBaseline />
+      <html lang="en">
+        <body>
+          <SessionProvider>
+            <Navbar/>{children}
+          </SessionProvider>
+        </body>
+      </html>
     </ThemeProvider>
   )
 };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,7 +27,7 @@ const categories = [
 
 const Home = () => {
   return (
-    <div className={styles.container}>
+    <Box component="div" width={'100%'} display="flex" justifyContent="center" alignItems="center" flexDirection="column" bgcolor='#314252'>
       <Box width={800} display="flex" alignItems="center" flexDirection="column" gap={2} bgcolor='#293745' p={3}>
         <Container disableGutters fixed maxWidth="xs" sx={{width: "15%"}}>
           <Image src={logo} alt="logo" />
@@ -53,7 +53,7 @@ const Home = () => {
               ))}
           </Grid>
         </Box>
-    </div>
+    </Box>
   );
 };
 

--- a/app/theme/theme.tsx
+++ b/app/theme/theme.tsx
@@ -17,6 +17,19 @@ const theme = createTheme({
       contrastText: '#fff', 
     },
   },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          color: "darkgrey",
+          backgroundColor: "grey",
+          // "& h1": {
+          //   color: "black"
+          // }
+        }
+      }
+    }
+  }
 });
 
 export default theme;


### PR DESCRIPTION
This is just a small update to page.tsx and layout.tsx.

- page.tsx
    - wrapping div is changed to a MUI Box and styling is changed from being contained in a css file to being 'inline'
    - could be useful to make a custom, resuable Box component in the future since a Box with the same styling will probably be used all across the app
- layout.tsx
    - removed the class name from the body div. The styling for the body is now in the theme.tsx

With this all we're closer to removing Tailwind and individual CSS files for all our components and being completely MUI based