### PR TITLE
Belinda_NextJS_Sprint_3_244_Transition_forget_password_page_to _MUI

### DIFF
--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { ChangeEventHandler, FormEventHandler, useState } from "react";
 // import styles from "./forgot-password-page.module.css";
-import { Container, Typography, Link, Button, Box, TextField } from '@mui/material';
+import { Container, Typography, Link, Button, Box, TextField, Paper } from '@mui/material';
 
 const ForgotPassword = () => {
   
@@ -27,27 +27,42 @@ const ForgotPassword = () => {
   return (
     <Container fixed maxWidth="lg" sx={{display: "flex", justifyContent: "center", alignItems: "center", bgcolor: '#12202d'}}>
 
+      <Paper
+        elevation={4}
+        sx={{
+          padding: "20px",
+          width: "400px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          marginTop: "2em",
+          marginBottom: "2em"
+        }}
+      >
+
       <Box  
         component="form"
         onSubmit={handleSubmit}
         noValidate
-        sx={{ mt: 1, width: "100%" }}>
+        sx={{ mt: 1, width: "100%"}}>
 
-          <Typography variant='h3' sx={{fontWeight: 'bold', fontSize: '1.8rem', marginBottom: '1rem', color: '#101c29'}}>
+          <Typography variant='h3' sx={{ fontFamily: 'Roboto, Helvetic, Arialsans-serif',fontWeight: 'bold', fontSize: '1.8rem', marginBottom: '1rem', color: 'black'}}>
           Forgot Password
           </Typography>
 
           <TextField
+            variant="outlined"
             label="Email"
             type="email"
             name="email"
             value={email}
             onChange={handleChange}
           />
-          <Button component='a' type="submit" variant="outlined">
+          <Button component='a' type="submit" variant="outlined" sx={{marginLeft: "1em",borderColor: "black"}}>
             Submit
           </Button>
       </Box>
+      </Paper>
     </Container>
   );
 };

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -25,7 +25,17 @@ const ForgotPassword = () => {
   };
 
   return (
-    <Container fixed maxWidth="lg" sx={{display: "flex", justifyContent: "center", alignItems: "center", bgcolor: '#12202d'}}>
+    <Container 
+      fixed 
+      maxWidth="lg" 
+      sx={{
+        display: "flex", 
+        justifyContent: "center", 
+        alignItems: "center", 
+        bgcolor: '#12202d', 
+        height: "100vh",
+        flexDirection: "column"
+      }}>
 
       <Paper
         elevation={4}
@@ -35,10 +45,12 @@ const ForgotPassword = () => {
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
-          marginTop: "2em",
-          marginBottom: "2em"
         }}
       >
+
+        <Typography component="h1" variant="h5">
+          Forgot Password
+        </Typography>
 
       <Box  
         component="form"
@@ -46,19 +58,27 @@ const ForgotPassword = () => {
         noValidate
         sx={{ mt: 1, width: "100%"}}>
 
-          <Typography variant='h3' sx={{ fontFamily: 'Roboto, Helvetic, Arialsans-serif',fontWeight: 'bold', fontSize: '1.8rem', marginBottom: '1rem', color: 'black'}}>
-          Forgot Password
-          </Typography>
+          
 
           <TextField
+            margin="normal"
+            required
+            fullWidth
             variant="outlined"
-            label="Email"
+            label="Email Address"
             type="email"
             name="email"
             value={email}
             onChange={handleChange}
           />
-          <Button component='a' type="submit" variant="outlined" sx={{marginLeft: "1em",borderColor: "black"}}>
+          <Button 
+            style={{ textTransform: "none" }}
+            color="primary"
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
+          >
             Submit
           </Button>
       </Box>

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 import React, { ChangeEventHandler, FormEventHandler, useState } from "react";
-import styles from "./forgot-password-page.module.css";
-import TextField from "@/components/InputFields";
-import { Container, Typography, Link, Button } from '@mui/material';
+// import styles from "./forgot-password-page.module.css";
+import { Container, Typography, Link, Button, Box, TextField } from '@mui/material';
 
 const ForgotPassword = () => {
   
@@ -27,23 +26,28 @@ const ForgotPassword = () => {
 
   return (
     <Container fixed maxWidth="lg" sx={{display: "flex", justifyContent: "center", alignItems: "center", bgcolor: '#12202d'}}>
-      <form className={styles.formContainer} onSubmit={handleSubmit}>
 
-        <Typography variant='h3' sx={{fontWeight: 'bold', fontSize: '1.8rem', marginBottom: '1rem', color: '#101c29'}}>
-        Forgot Password
-        </Typography>
+      <Box  
+        component="form"
+        onSubmit={handleSubmit}
+        noValidate
+        sx={{ mt: 1, width: "100%" }}>
 
-        <TextField
-          label="Email"
-          type="email"
-          name="email"
-          value={email}
-          onChange={handleChange}
-        />
-        <Button component='a' type="submit" variant="outlined">
-          Submit
-        </Button>
-      </form>
+          <Typography variant='h3' sx={{fontWeight: 'bold', fontSize: '1.8rem', marginBottom: '1rem', color: '#101c29'}}>
+          Forgot Password
+          </Typography>
+
+          <TextField
+            label="Email"
+            type="email"
+            name="email"
+            value={email}
+            onChange={handleChange}
+          />
+          <Button component='a' type="submit" variant="outlined">
+            Submit
+          </Button>
+      </Box>
     </Container>
   );
 };

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 import React, { ChangeEventHandler, FormEventHandler, useState } from "react";
 import styles from "./forgot-password-page.module.css";
-import InputField from "@/components/InputFields";
+import TextField from "@/components/InputFields";
+import { Container, Typography, Link, Button } from '@mui/material';
 
 const ForgotPassword = () => {
   
@@ -25,21 +26,25 @@ const ForgotPassword = () => {
   };
 
   return (
-    <div className={styles.container}>
+    <Container fixed maxWidth="lg" sx={{display: "flex", justifyContent: "center", alignItems: "center", bgcolor: '#12202d'}}>
       <form className={styles.formContainer} onSubmit={handleSubmit}>
-        <h1 className={styles.title}>Forgot Password</h1>
-        <InputField
+
+        <Typography variant='h3' sx={{fontWeight: 'bold', fontSize: '1.8rem', marginBottom: '1rem', color: '#101c29'}}>
+        Forgot Password
+        </Typography>
+
+        <TextField
           label="Email"
           type="email"
           name="email"
           value={email}
           onChange={handleChange}
         />
-        <button type="submit" className={styles.submitButton}>
+        <Button component='a' type="submit" variant="outlined">
           Submit
-        </button>
+        </Button>
       </form>
-    </div>
+    </Container>
   );
 };
 


### PR DESCRIPTION
I have transitioned the forget-password page into the MUI CSS framework. 

NOTE: the form tag is still using the old CSS but cannot seem to have MUI syntax within the form tag. Let me know if you would like to me to transition the form tag into the new syntax via custom function method using MUI syntax.

