### PR TITLE
belindas-closet-nextjs_4_254_edit-user-role-functionality

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -49,6 +49,7 @@ const Signin = () => {
       setError("Invalid email or password");
     } else {
       const { token } = await res.json();
+      localStorage.setItem('token', token);
       const userRole = JSON.parse(atob(token.split(".")[1])).role; // decode token to get user role
       // Redirect to user page
       if (userRole === "admin") {

--- a/components/EditUserRoleDialog.tsx
+++ b/components/EditUserRoleDialog.tsx
@@ -31,8 +31,8 @@ interface ConfirmationDialogRawProps {
  * @param props - The component props.
  * @returns The rendered ConfirmationDialogRaw component.
  */
-export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
-  const { onClose, value: valueProp, open, ...other } = props;
+export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps & { user: UserCardProps } ) {
+  const { onClose, value: valueProp, open, user, ...other } = props;
   const [value, setValue] = useState(valueProp);
   const radioGroupRef = useRef<HTMLElement>(null);
 
@@ -62,9 +62,27 @@ export function ConfirmationDialogRaw(props: ConfirmationDialogRawProps) {
    * Handles the click event when the user confirms the role update.
    * @returns {void}
    */
-  const handleOk = () => {
-    onClose(value);
+  const handleOk = async () => {
+    const token = localStorage.getItem('token');
+    console.log('Token:', token);
     // TODO: Update user role in the database
+    try {
+      const response = await fetch(`http://localhost:3000/api/user/update/${user.id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`
+        },
+        body: JSON.stringify({ role: value })
+      });
+      if (response.ok) {
+        onClose(value);
+      } else {
+        console.error('Failed to update user role:', response.statusText);
+      }
+    } catch (error) {
+      console.error('Error updating user role:', error);
+    }
   };
 
   /**
@@ -167,6 +185,7 @@ export default function EditUserRoleDialog({
           open={open}
           onClose={handleClose}
           value={value}
+          user={user}
         />
       </List>
     </Box>


### PR DESCRIPTION
Resolves #254 

This PR adds functonality to the Edit User Role page by calling the fetching the update user API endpoint after the user chooses a role and clicks the "Ok" option in the user role dialog. The user role of the user is updated in the database. Only admin users have the authorization to edit the user role.

NOTE: For this PR to work, you must have this [PR](https://github.com/SeattleColleges/belindas-closet-nestjs/pull/94) running on the backend.

Before updating the user role:

<img width="419" alt="Screenshot 2024-03-09 061241" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/8eb1acc7-f7f6-4b2b-940f-865aa89c36eb">
<img width="577" alt="Screenshot 2024-03-09 063807" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/631fb848-d361-4921-a3f9-c2e48c2203ca">

After updating the user role to admin (after refreshing page):
<img width="582" alt="Screenshot 2024-03-09 062545" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/c48b5d24-8225-410d-b4c8-67c2420f2310">
<img width="459" alt="Screenshot 2024-03-09 061435" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/d66e060d-8980-461e-8ec1-99e3a75f1a90">


Related to #253