### PR TITLE
belinda-closet-nextjs_3_235_add-profile-icon

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -19,7 +19,7 @@ import {
 
 import MenuIcon from "@mui/icons-material/Menu";
 import CategoryDropDownMenu from "./CategoryDropDownMenu";
-
+import ProfileDropDown from './ProfileDropDown'; 
 const drawerWidth = 240;
 const navItems = ["Home", "Sign In", "Donation"];
 const links = ["/", "/auth/sign-in", "/donation-info"];
@@ -89,6 +89,7 @@ export default function Navbar() {
               ))}
             </Grid>
           </Box>
+        <ProfileDropDown />
         </Toolbar>
       </AppBar>
       <nav>

--- a/components/ProfileDropDown.tsx
+++ b/components/ProfileDropDown.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Menu, MenuItem, IconButton, Tooltip } from '@mui/material';
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
+import Link from 'next/link';
+
+const ProfileDropDown = () => {
+  const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const open = Boolean(anchorEl);
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <Tooltip title="Account settings">
+        <IconButton
+          onClick={handleClick}
+          size="large"
+          aria-label="account of current user"
+          aria-controls="menu-appbar"
+          aria-haspopup="true"
+          color="inherit"
+        >
+          <AccountCircleIcon />
+        </IconButton>
+      </Tooltip>
+      <Menu
+        id="menu-appbar"
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        keepMounted
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        open={open}
+        onClose={handleClose}
+      >
+        <Link href="/profile" passHref>
+          <MenuItem onClick={handleClose}>Profile</MenuItem>
+        </Link>
+        <Link href="/account" passHref>
+          <MenuItem onClick={handleClose}>Account</MenuItem>
+        </Link>
+        <Link href="/auth/sign-in" passHref>
+          <MenuItem onClick={handleClose}>Sign In</MenuItem>
+        </Link>
+      </Menu>
+    </div>
+  );
+};
+
+export default ProfileDropDown;
+


### PR DESCRIPTION
This is related to #235 I added a Profile Icon to the Navbar that has a link to Account, Profile and Signin page. I tried adding the Signout page also but I was struggling with the linking it to the signout authentication so I left it out. 

This is the profile icon in the navbar
<img width="410" alt="Screenshot 2024-03-14 at 1 45 29 PM" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/117953848/4ff5e81e-69a1-426d-83d8-1be56ba83334">
This is the the Profile dropdown
<img width="175" alt="Screenshot 2024-03-14 at 1 45 46 PM" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/117953848/6bbc7284-949a-4fbd-a5e4-08f2d101cd43">
This is the Profile Page when click from the dropdown
<img width="935" alt="Screenshot 2024-03-14 at 1 46 04 PM" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/117953848/cc347838-0146-4423-9384-6070786b633f">
This the Account Page when click from the dropdown (Nothing to show at the moment)
<img width="912" alt="Screenshot 2024-03-14 at 1 46 18 PM" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/117953848/71324abf-91b8-4d38-a218-d17909f011e6">
This the the Signin Page when click from the dropdown
<img width="909" alt="Screenshot 2024-03-14 at 1 46 26 PM" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/117953848/7218cc0c-ef30-4a1e-8045-7048eaba49a8">
