### PR TITLE
belinda-nextjs-bug-269-error-message-display-inconsistent

### DIFF
--- a/app/auth/change-password-page/page.tsx
+++ b/app/auth/change-password-page/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@mui/material";
 import ErrorAlert from "@/components/ErrorAlert";
 import SuccessAlert from "@/components/SuccessAlert";
+import { useRouter } from "next/navigation";
 
 const ChangePasswordPage = () => {
   const [password, setPassword] = useState({
@@ -44,6 +45,9 @@ const ChangePasswordPage = () => {
   const toggleConfirmPasswordVisibility = () => {
     setShowConfirmPassword(!showConfirmPassword);
   };
+
+  // router
+  const router = useRouter();
 
   // handle change event
   const handleChange: ChangeEventHandler<HTMLInputElement> = ({ target }) => {
@@ -104,8 +108,11 @@ const ChangePasswordPage = () => {
         return;
       } 
       setError("");
-      setPassword({ newPassword: "", confirmPassword: "" });
-      setSuccess("Password changed successfully");
+      //set delay to show success message
+      setSuccess("Password changed successfully, redirecting to sign in page");
+      setTimeout(() => {
+        router.push("/auth/sign-in");
+      }, 3000);
     } catch (error) {
       console.error("Error changing password:", error);
     } finally {

--- a/app/auth/change-password-page/page.tsx
+++ b/app/auth/change-password-page/page.tsx
@@ -5,7 +5,6 @@ import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
 import {
-  Alert,
   Box,
   Button,
   CircularProgress,
@@ -16,6 +15,8 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import ErrorAlert from "@/components/ErrorAlert";
+import SuccessAlert from "@/components/SuccessAlert";
 
 const ChangePasswordPage = () => {
   const [password, setPassword] = useState({
@@ -67,6 +68,12 @@ const ChangePasswordPage = () => {
       return;
     }
 
+    // Check if password is less than 8 characters
+    if (newPassword.length < 8) {
+      setError("Password must be at least 8 characters long");
+      return;
+    }
+
     // token after login
     const token = localStorage.getItem("token") || null;
 
@@ -83,10 +90,7 @@ const ChangePasswordPage = () => {
         "http://localhost:3000/api/auth/change-password",
         {
           method: "POST",
-          body: JSON.stringify({
-            newPassword,
-            confirmPassword,
-          }),
+          body: JSON.stringify(password),
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
@@ -94,19 +98,16 @@ const ChangePasswordPage = () => {
         }
       );
       if (!res.ok) {
-        setError(error || "Failed to change password");
+        const { message } = await res.json();
+        setError(message);
         setSuccess("");
-      } else {
-        // reset the form
-        setPassword({ newPassword: "", confirmPassword: "" });
-        setSuccess("Password changed successfully");
-        setError("");
-      }
+        return;
+      } 
+      setError("");
+      setPassword({ newPassword: "", confirmPassword: "" });
+      setSuccess("Password changed successfully");
     } catch (error) {
       console.error("Error changing password:", error);
-      setError("Failed to change password");
-      setLoading(false);
-      setSuccess("");
     } finally {
       setLoading(false);
     }    
@@ -206,16 +207,8 @@ const ChangePasswordPage = () => {
               ),
             }}
           />
-          {error && (
-            <Alert severity="error" sx={{ mb: 2 }}>
-              {error}
-            </Alert>
-          )}
-          {success && (
-            <Alert severity="success" sx={{ mb: 2 }}>
-              {success}
-            </Alert>
-          )}
+          {error && <ErrorAlert message={error} />}
+          {success && <SuccessAlert message={success} />}
           <Button
             type="submit"
             fullWidth


### PR DESCRIPTION
Resolves #269 
Related #252 

This PR will update the change password page by modifying the error message display.

**Success**

![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/97ec6243-bb8e-413a-8574-6562dc4d547d)

**Error**

1. Empty fields

![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/601b4cb5-151c-4e5b-a22e-00a38b5acdc0)

2. Password isn't long enough

![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/d79385de-c030-4754-bcdf-a45b381d4f23)

3. Passwords do not match

![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/3bf193e7-8ca7-496c-9dfa-2ce3d631441b)

4. New password is the same as the previous one

![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/89433b9f-597b-48e1-a46e-abfeb25d3c26)


