### PR TITLE
belindas-closet-nextjs_4_194_standardize_wrapper

### DIFF
--- a/app/add-product-page/page.tsx
+++ b/app/add-product-page/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import React, { useState } from "react";
-import { FormControl, Stack, InputLabel, Box, Button, TextField, Typography, Select, MenuItem, } from '@mui/material';
+import { FormControl, Stack, InputLabel, Button, TextField, Typography, Select, MenuItem, } from '@mui/material';
+import WrapperDiv from '@/components/WrapperDiv'
 import {
   ProductTypeList,
   ProductGenderList,
@@ -102,7 +103,7 @@ const AddProduct = () => {
   };
 
   return (
-    <Box width={800} display="flex" alignItems="center" flexDirection="column" gap={2} bgcolor='#293745' p={3}>
+    <WrapperDiv>
       <form onSubmit={handleSubmit}>
         <FormControl>
           <Typography component='h1' variant='h3' sx={{color: 'white', marginBottom: "15px"}}>
@@ -224,7 +225,7 @@ const AddProduct = () => {
           </Button>
         </FormControl>
       </form>
-    </Box>    
+    </WrapperDiv>    
   );
 };
 

--- a/app/add-product-page/page.tsx
+++ b/app/add-product-page/page.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState } from "react";
 import { FormControl, Stack, InputLabel, Button, TextField, Typography, Select, MenuItem, } from '@mui/material';
-import WrapperDiv from '@/components/WrapperDiv'
 import {
   ProductTypeList,
   ProductGenderList,
@@ -103,129 +102,127 @@ const AddProduct = () => {
   };
 
   return (
-    <WrapperDiv>
-      <form onSubmit={handleSubmit}>
-        <FormControl>
-          <Typography component='h1' variant='h3' sx={{color: 'white', marginBottom: "15px"}}>
-              Add a Product
-            </Typography>
+    <form onSubmit={handleSubmit}>
+      <FormControl>
+        <Typography component='h1' variant='h3' sx={{color: 'white', marginBottom: "15px"}}>
+            Add a Product
+          </Typography>
 
-          {/* Product Type Field */}
-          <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
-            <InputLabel id="type-selectlabel">Product Type</InputLabel>
-            <Select labelId="type-selectlabel" 
-              id="type-select" 
-              value={productType}
-              aria-describedby="product-type-field"
-              onChange={handleProductTypeSelect}
-            >
-              {Object.values(ProductTypeList).map((type) => (
-                <MenuItem value={type} key={type}>{type}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          {/* Product Gender Field */}
-          <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
-            <InputLabel id="gender-selectlabel">Product Gender</InputLabel>
-            <Select labelId="gender-selectlabel" 
-              id="gender-select" 
-              value={productGender}
-              aria-describedby="product-gender-field"
-              onChange={handleProductGenderSelect}
-            >
-              {Object.values(ProductGenderList).map((gender) => (
-                <MenuItem value={gender} key={gender}>{gender}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          {/* Product Size Shoe Field */}
-          <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
-            <InputLabel id="shoesize-selectlabel">Shoe Size</InputLabel>
-            <Select labelId="shoesize-selectlabel" 
-              id="shoesize-select" 
-              value={productSizeShoe}
-              aria-describedby="product-shoesize-field"
-              onChange={handleProductSizeShoeSelect}
-            >
-              {Object.values(ProductSizeShoeList).map((size) => (
-                <MenuItem value={size} key={size}>{size}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          {/* Product Size Field */}
-          <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
-            <InputLabel id="size-selectlabel">Product Size</InputLabel>
-            <Select labelId="size-selectlabel" 
-              id="size-select" 
-              value={productSizes}
-              aria-describedby="product-size-field"
-              onChange={handleProductSizeSelect}
-            >
-              {Object.values(ProductSizesList).map((size) => (
-                <MenuItem value={size} key={size}>{size}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          {/* Product Size Pants Waist Field */}
-          <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
-            <InputLabel id="waistsize-selectlabel">Waist Size</InputLabel>
-            <Select labelId="waistsize-selectlabel" 
-              id="waistsize-select" 
-              value={productSizePantsWaist}
-              aria-describedby="product-waist-size-field"
-              onChange={handleProductSizePantsWaistSelect}
-            >
-              {Object.values(ProductSizePantsWaistList).map((size) => (
-                <MenuItem value={size} key={size}>{size}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          {/* Product Size Pants Inseam Field */}
-          <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
-            <InputLabel id="inseamsize-selectlabel">Inseam Length</InputLabel>
-            <Select labelId="inseamsize-selectlabel" 
-              id="inseamsize-select" 
-              value={productSizePantsInseam}
-              aria-describedby="product-inseam-size-field"
-              onChange={handleProductSizePantsInseamSelect}
-            >
-              {Object.values(ProductSizePantsInseamList).map((size) => (
-                <MenuItem value={size} key={size}>{size}</MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          {/* Product Description Field */}
-          <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
-            <TextField label="Product Description"
-              aria-describedby="product-description-field"
-              id="product-description"
-              onChange={handleDescriptionChange}
-              multiline
-              minRows={2}
-              variant="filled"/>
-          </FormControl>
-          
-          {/* Product Upload Image Field */}
-          <Stack direction="row" alignItems="center" justifyContent="center" spacing={2} sx={{ m: 1 }}>
-            <Button variant="contained" component="label" sx={{ width: 1 }}>
-              Upload Image
-              <input hidden multiple type="file" onChange={handleImageUpload} value={productImage}/>
-            </Button>
-          </Stack>
-
-          {/* Submit Button */}
-          <Button variant="contained" color="primary" onClick={handleSubmit} type="submit" sx={{ mt: 1 }}>
-            Submit
-          </Button>
+        {/* Product Type Field */}
+        <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
+          <InputLabel id="type-selectlabel">Product Type</InputLabel>
+          <Select labelId="type-selectlabel" 
+            id="type-select" 
+            value={productType}
+            aria-describedby="product-type-field"
+            onChange={handleProductTypeSelect}
+          >
+            {Object.values(ProductTypeList).map((type) => (
+              <MenuItem value={type} key={type}>{type}</MenuItem>
+            ))}
+          </Select>
         </FormControl>
-      </form>
-    </WrapperDiv>    
+
+        {/* Product Gender Field */}
+        <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
+          <InputLabel id="gender-selectlabel">Product Gender</InputLabel>
+          <Select labelId="gender-selectlabel" 
+            id="gender-select" 
+            value={productGender}
+            aria-describedby="product-gender-field"
+            onChange={handleProductGenderSelect}
+          >
+            {Object.values(ProductGenderList).map((gender) => (
+              <MenuItem value={gender} key={gender}>{gender}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* Product Size Shoe Field */}
+        <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
+          <InputLabel id="shoesize-selectlabel">Shoe Size</InputLabel>
+          <Select labelId="shoesize-selectlabel" 
+            id="shoesize-select" 
+            value={productSizeShoe}
+            aria-describedby="product-shoesize-field"
+            onChange={handleProductSizeShoeSelect}
+          >
+            {Object.values(ProductSizeShoeList).map((size) => (
+              <MenuItem value={size} key={size}>{size}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* Product Size Field */}
+        <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
+          <InputLabel id="size-selectlabel">Product Size</InputLabel>
+          <Select labelId="size-selectlabel" 
+            id="size-select" 
+            value={productSizes}
+            aria-describedby="product-size-field"
+            onChange={handleProductSizeSelect}
+          >
+            {Object.values(ProductSizesList).map((size) => (
+              <MenuItem value={size} key={size}>{size}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* Product Size Pants Waist Field */}
+        <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
+          <InputLabel id="waistsize-selectlabel">Waist Size</InputLabel>
+          <Select labelId="waistsize-selectlabel" 
+            id="waistsize-select" 
+            value={productSizePantsWaist}
+            aria-describedby="product-waist-size-field"
+            onChange={handleProductSizePantsWaistSelect}
+          >
+            {Object.values(ProductSizePantsWaistList).map((size) => (
+              <MenuItem value={size} key={size}>{size}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* Product Size Pants Inseam Field */}
+        <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
+          <InputLabel id="inseamsize-selectlabel">Inseam Length</InputLabel>
+          <Select labelId="inseamsize-selectlabel" 
+            id="inseamsize-select" 
+            value={productSizePantsInseam}
+            aria-describedby="product-inseam-size-field"
+            onChange={handleProductSizePantsInseamSelect}
+          >
+            {Object.values(ProductSizePantsInseamList).map((size) => (
+              <MenuItem value={size} key={size}>{size}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        {/* Product Description Field */}
+        <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
+          <TextField label="Product Description"
+            aria-describedby="product-description-field"
+            id="product-description"
+            onChange={handleDescriptionChange}
+            multiline
+            minRows={2}
+            variant="filled"/>
+        </FormControl>
+        
+        {/* Product Upload Image Field */}
+        <Stack direction="row" alignItems="center" justifyContent="center" spacing={2} sx={{ m: 1 }}>
+          <Button variant="contained" component="label" sx={{ width: 1 }}>
+            Upload Image
+            <input hidden multiple type="file" onChange={handleImageUpload} value={productImage}/>
+          </Button>
+        </Stack>
+
+        {/* Submit Button */}
+        <Button variant="contained" color="primary" onClick={handleSubmit} type="submit" sx={{ mt: 1 }}>
+          Submit
+        </Button>
+      </FormControl>
+    </form>
   );
 };
 

--- a/app/admin-page/page.tsx
+++ b/app/admin-page/page.tsx
@@ -1,4 +1,3 @@
-import WrapperDiv from '@/components/WrapperDiv'
 // import { Link } from 'react-router-dom'; // Import the Link component from react-router-dom
 
 const Admin = () => {
@@ -7,7 +6,7 @@ const Admin = () => {
   };
 
   return (
-    <WrapperDiv>
+    <div>
       <h1> Wellcome to the PAGE      </h1>
       <p>FIX: allow only users with admin role to be routed to this page</p>
       {/* <Link to="/add-product-page"> */}
@@ -25,7 +24,7 @@ const Admin = () => {
           Edit User Roles
         </button>
       {/* </Link> */}
-    </WrapperDiv>
+    </div>
   );
 };
 

--- a/app/admin-page/page.tsx
+++ b/app/admin-page/page.tsx
@@ -1,3 +1,4 @@
+import WrapperDiv from '@/components/WrapperDiv'
 // import { Link } from 'react-router-dom'; // Import the Link component from react-router-dom
 
 const Admin = () => {
@@ -6,7 +7,7 @@ const Admin = () => {
   };
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
+    <WrapperDiv>
       <h1> Wellcome to the PAGE      </h1>
       <p>FIX: allow only users with admin role to be routed to this page</p>
       {/* <Link to="/add-product-page"> */}
@@ -24,7 +25,7 @@ const Admin = () => {
           Edit User Roles
         </button>
       {/* </Link> */}
-    </div>
+    </WrapperDiv>
   );
 };
 

--- a/app/auth/change-password-page/page.tsx
+++ b/app/auth/change-password-page/page.tsx
@@ -4,7 +4,6 @@ import logo from "@/app/logo.png";
 import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
-import WrapperDiv from '@/components/WrapperDiv';
 import {
   Box,
   Button,
@@ -122,102 +121,98 @@ const ChangePasswordPage = () => {
   };
 
   if (loading) {
-    <WrapperDiv>
-      <CircularProgress />
-    </WrapperDiv>;
+    <CircularProgress />
   }
 
   return (
-    <WrapperDiv>
-      <Paper elevation={6} sx={{ width: "100%", maxWidth: 400, padding: 3 }}>
-        <Container
-          disableGutters
-          fixed
-          maxWidth="xs"
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-        >
-          <Image
-            src={logo}
-            alt="logo"
-            style={{ width: 50, height: 50, marginBottom: 10 }}
-          />
-        </Container>
-        <Typography
-          component="h1"
-          variant="h5"
-          textAlign="center"
+    <Paper elevation={6} sx={{ width: "100%", maxWidth: 400, padding: 3 }}>
+      <Container
+        disableGutters
+        fixed
+        maxWidth="xs"
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Image
+          src={logo}
+          alt="logo"
+          style={{ width: 50, height: 50, marginBottom: 10 }}
+        />
+      </Container>
+      <Typography
+        component="h1"
+        variant="h5"
+        textAlign="center"
+        sx={{ mb: 2 }}
+      >
+        Change Password
+      </Typography>
+      <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
+        <TextField
           sx={{ mb: 2 }}
+          variant="outlined"
+          margin="normal"
+          required={true}
+          fullWidth
+          id="newPassword"
+          label="New Password"
+          name="newPassword"
+          type={showPassword ? "text" : "password"}
+          value={password.newPassword}
+          onChange={handleChange}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={togglePasswordVisibility}
+                >
+                  {showPassword ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        <TextField
+          sx={{ mb: 2 }}
+          variant="outlined"
+          margin="normal"
+          required={true}
+          fullWidth
+          id="confirmPassword"
+          label="Confirm Password"
+          name="confirmPassword"
+          type={showConfirmPassword ? "text" : "password"}
+          value={password.confirmPassword}
+          onChange={handleChange}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle confirm password visibility"
+                  onClick={toggleConfirmPasswordVisibility}
+                >
+                  {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        {error && <ErrorAlert message={error} />}
+        {success && <SuccessAlert message={success} />}
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          sx={{ mt: 3, mb: 2 }}
         >
           Change Password
-        </Typography>
-        <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
-          <TextField
-            sx={{ mb: 2 }}
-            variant="outlined"
-            margin="normal"
-            required={true}
-            fullWidth
-            id="newPassword"
-            label="New Password"
-            name="newPassword"
-            type={showPassword ? "text" : "password"}
-            value={password.newPassword}
-            onChange={handleChange}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="toggle password visibility"
-                    onClick={togglePasswordVisibility}
-                  >
-                    {showPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-          <TextField
-            sx={{ mb: 2 }}
-            variant="outlined"
-            margin="normal"
-            required={true}
-            fullWidth
-            id="confirmPassword"
-            label="Confirm Password"
-            name="confirmPassword"
-            type={showConfirmPassword ? "text" : "password"}
-            value={password.confirmPassword}
-            onChange={handleChange}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="toggle confirm password visibility"
-                    onClick={toggleConfirmPasswordVisibility}
-                  >
-                    {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-          {error && <ErrorAlert message={error} />}
-          {success && <SuccessAlert message={success} />}
-          <Button
-            type="submit"
-            fullWidth
-            variant="contained"
-            sx={{ mt: 3, mb: 2 }}
-          >
-            Change Password
-          </Button>
-        </Box>
-      </Paper>
-    </WrapperDiv>
+        </Button>
+      </Box>
+    </Paper>
   );
 };
 export default ChangePasswordPage;

--- a/app/auth/change-password-page/page.tsx
+++ b/app/auth/change-password-page/page.tsx
@@ -4,6 +4,7 @@ import logo from "@/app/logo.png";
 import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
+import WrapperDiv from '@/components/WrapperDiv';
 import {
   Box,
   Button,
@@ -121,23 +122,13 @@ const ChangePasswordPage = () => {
   };
 
   if (loading) {
-    <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
+    <WrapperDiv>
       <CircularProgress />
-    </Box>;
+    </WrapperDiv>;
   }
 
   return (
-    <Container
-      maxWidth="lg"
-      sx={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        bgcolor: "#12202d",
-        height: "100vh",
-        flexDirection: "column",
-      }}
-    >
+    <WrapperDiv>
       <Paper elevation={6} sx={{ width: "100%", maxWidth: 400, padding: 3 }}>
         <Container
           disableGutters
@@ -226,7 +217,7 @@ const ChangePasswordPage = () => {
           </Button>
         </Box>
       </Paper>
-    </Container>
+    </WrapperDiv>
   );
 };
 export default ChangePasswordPage;

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 import React, { ChangeEventHandler, FormEventHandler, useState } from "react";
 // import styles from "./forgot-password-page.module.css";
-import { Container, Typography, Link, Button, Box, TextField, Paper } from '@mui/material';
+import { Typography, Button, Box, TextField, Paper } from '@mui/material';
+import WrapperDiv from '@/components/WrapperDiv';
 
 const ForgotPassword = () => {
   
@@ -25,18 +26,7 @@ const ForgotPassword = () => {
   };
 
   return (
-    <Container 
-      fixed 
-      maxWidth="lg" 
-      sx={{
-        display: "flex", 
-        justifyContent: "center", 
-        alignItems: "center", 
-        bgcolor: '#12202d', 
-        height: "100vh",
-        flexDirection: "column"
-      }}>
-
+    <WrapperDiv>
       <Paper
         elevation={4}
         sx={{
@@ -83,7 +73,7 @@ const ForgotPassword = () => {
           </Button>
       </Box>
       </Paper>
-    </Container>
+    </WrapperDiv>
   );
 };
 

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 import React, { ChangeEventHandler, FormEventHandler, useState } from "react";
-// import styles from "./forgot-password-page.module.css";
 import { Typography, Button, Box, TextField, Paper } from '@mui/material';
-import WrapperDiv from '@/components/WrapperDiv';
 
 const ForgotPassword = () => {
   
@@ -26,54 +24,52 @@ const ForgotPassword = () => {
   };
 
   return (
-    <WrapperDiv>
-      <Paper
-        elevation={4}
-        sx={{
-          padding: "20px",
-          width: "400px",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-        }}
-      >
+    <Paper
+      elevation={4}
+      sx={{
+        padding: "20px",
+        width: "400px",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+      }}
+    >
 
-        <Typography component="h1" variant="h5">
-          Forgot Password
-        </Typography>
+      <Typography component="h1" variant="h5">
+        Forgot Password
+      </Typography>
 
-      <Box  
-        component="form"
-        onSubmit={handleSubmit}
-        noValidate
-        sx={{ mt: 1, width: "100%"}}>
+    <Box  
+      component="form"
+      onSubmit={handleSubmit}
+      noValidate
+      sx={{ mt: 1, width: "100%"}}>
 
-          
+        
 
-          <TextField
-            margin="normal"
-            required
-            fullWidth
-            variant="outlined"
-            label="Email Address"
-            type="email"
-            name="email"
-            value={email}
-            onChange={handleChange}
-          />
-          <Button 
-            style={{ textTransform: "none" }}
-            color="primary"
-            type="submit"
-            fullWidth
-            variant="contained"
-            sx={{ mt: 3, mb: 2 }}
-          >
-            Submit
-          </Button>
-      </Box>
-      </Paper>
-    </WrapperDiv>
+        <TextField
+          margin="normal"
+          required
+          fullWidth
+          variant="outlined"
+          label="Email Address"
+          type="email"
+          name="email"
+          value={email}
+          onChange={handleChange}
+        />
+        <Button 
+          style={{ textTransform: "none" }}
+          color="primary"
+          type="submit"
+          fullWidth
+          variant="contained"
+          sx={{ mt: 3, mb: 2 }}
+        >
+          Submit
+        </Button>
+    </Box>
+    </Paper>
   );
 };
 

--- a/app/auth/reset-password-page/page.tsx
+++ b/app/auth/reset-password-page/page.tsx
@@ -14,7 +14,6 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import WrapperDiv from '@/components/WrapperDiv';
 
 const ResetPasswordPage = () => {
   const [password, setPassword] = useState({
@@ -72,99 +71,97 @@ const ResetPasswordPage = () => {
   };
 
   return (
-    <WrapperDiv>
-      <Paper elevation={6} sx={{ width: "100%", maxWidth: 400, padding: 3 }}>
-        <Container
-          disableGutters
-          fixed
-          maxWidth="xs"
-          sx={{
-            display: "flex",
-            justifyContent: "center",
-            alignItems: "center",
-          }}
-        >
-          <Image
-            src={logo}
-            alt="logo"
-            style={{ width: 50, height: 50, marginBottom: 10 }}
-          />
-        </Container>
-        <Typography
-          component="h1"
-          variant="h5"
-          textAlign="center"
+    <Paper elevation={6} sx={{ width: "100%", maxWidth: 400, padding: 3 }}>
+      <Container
+        disableGutters
+        fixed
+        maxWidth="xs"
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <Image
+          src={logo}
+          alt="logo"
+          style={{ width: 50, height: 50, marginBottom: 10 }}
+        />
+      </Container>
+      <Typography
+        component="h1"
+        variant="h5"
+        textAlign="center"
+        sx={{ mb: 2 }}
+      >
+        Reset Password
+      </Typography>
+      <Box
+        component="form"
+        onSubmit={handleSubmit}
+        noValidate
+        sx={{ mt: 1 }}
+      >
+        <TextField
           sx={{ mb: 2 }}
+          variant="outlined"
+          margin="normal"
+          required
+          fullWidth
+          id="newPassword"
+          label="New Password"
+          name="newPassword"
+          type={showPassword ? "text" : "password"}
+          value={newPassword}
+          onChange={handleChange}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle password visibility"
+                  onClick={togglePasswordVisibility}
+                >
+                  {showPassword ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        <TextField
+          sx={{ mb: 2 }}
+          variant="outlined"
+          margin="normal"
+          required
+          fullWidth
+          id="confirmPassword"
+          label="Confirm Password"
+          name="confirmPassword"
+          type={showConfirmPassword ? "text" : "password"}
+          value={confirmPassword}
+          onChange={handleChange}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  aria-label="toggle confirm password visibility"
+                  onClick={toggleConfirmPasswordVisibility}
+                >
+                  {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
+                </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
+        <Button
+          type="submit"
+          fullWidth
+          variant="contained"
+          sx={{ mt: 3, mb: 2 }}
         >
           Reset Password
-        </Typography>
-        <Box
-          component="form"
-          onSubmit={handleSubmit}
-          noValidate
-          sx={{ mt: 1 }}
-        >
-          <TextField
-            sx={{ mb: 2 }}
-            variant="outlined"
-            margin="normal"
-            required
-            fullWidth
-            id="newPassword"
-            label="New Password"
-            name="newPassword"
-            type={showPassword ? "text" : "password"}
-            value={newPassword}
-            onChange={handleChange}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="toggle password visibility"
-                    onClick={togglePasswordVisibility}
-                  >
-                    {showPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-          <TextField
-            sx={{ mb: 2 }}
-            variant="outlined"
-            margin="normal"
-            required
-            fullWidth
-            id="confirmPassword"
-            label="Confirm Password"
-            name="confirmPassword"
-            type={showConfirmPassword ? "text" : "password"}
-            value={confirmPassword}
-            onChange={handleChange}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton
-                    aria-label="toggle confirm password visibility"
-                    onClick={toggleConfirmPasswordVisibility}
-                  >
-                    {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-          <Button
-            type="submit"
-            fullWidth
-            variant="contained"
-            sx={{ mt: 3, mb: 2 }}
-          >
-            Reset Password
-          </Button>
-        </Box>
-      </Paper>
-    </WrapperDiv>
+        </Button>
+      </Box>
+    </Paper>
   );
 };
 export default ResetPasswordPage;

--- a/app/auth/reset-password-page/page.tsx
+++ b/app/auth/reset-password-page/page.tsx
@@ -14,6 +14,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
+import WrapperDiv from '@/components/WrapperDiv';
 
 const ResetPasswordPage = () => {
   const [password, setPassword] = useState({
@@ -71,117 +72,99 @@ const ResetPasswordPage = () => {
   };
 
   return (
-    <Container
-      maxWidth="lg"
-      sx={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        bgcolor: "#12202d",
-      }}
-    >
-      <Box
-        width={800}
-        display="flex"
-        alignItems="center"
-        flexDirection="column"
-        bgcolor="#293745"
-        gap={2}
-        p={3}
-      >
-        <Paper elevation={6} sx={{ width: "100%", maxWidth: 400, padding: 3 }}>
-          <Container
-            disableGutters
-            fixed
-            maxWidth="xs"
-            sx={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-            }}
-          >
-            <Image
-              src={logo}
-              alt="logo"
-              style={{ width: 50, height: 50, marginBottom: 10 }}
-            />
-          </Container>
-          <Typography
-            component="h1"
-            variant="h5"
-            textAlign="center"
+    <WrapperDiv>
+      <Paper elevation={6} sx={{ width: "100%", maxWidth: 400, padding: 3 }}>
+        <Container
+          disableGutters
+          fixed
+          maxWidth="xs"
+          sx={{
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+          }}
+        >
+          <Image
+            src={logo}
+            alt="logo"
+            style={{ width: 50, height: 50, marginBottom: 10 }}
+          />
+        </Container>
+        <Typography
+          component="h1"
+          variant="h5"
+          textAlign="center"
+          sx={{ mb: 2 }}
+        >
+          Reset Password
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          noValidate
+          sx={{ mt: 1 }}
+        >
+          <TextField
             sx={{ mb: 2 }}
+            variant="outlined"
+            margin="normal"
+            required
+            fullWidth
+            id="newPassword"
+            label="New Password"
+            name="newPassword"
+            type={showPassword ? "text" : "password"}
+            value={newPassword}
+            onChange={handleChange}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle password visibility"
+                    onClick={togglePasswordVisibility}
+                  >
+                    {showPassword ? <Visibility /> : <VisibilityOff />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+            sx={{ mb: 2 }}
+            variant="outlined"
+            margin="normal"
+            required
+            fullWidth
+            id="confirmPassword"
+            label="Confirm Password"
+            name="confirmPassword"
+            type={showConfirmPassword ? "text" : "password"}
+            value={confirmPassword}
+            onChange={handleChange}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle confirm password visibility"
+                    onClick={toggleConfirmPasswordVisibility}
+                  >
+                    {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+          <Button
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
           >
             Reset Password
-          </Typography>
-          <Box
-            component="form"
-            onSubmit={handleSubmit}
-            noValidate
-            sx={{ mt: 1 }}
-          >
-            <TextField
-              sx={{ mb: 2 }}
-              variant="outlined"
-              margin="normal"
-              required
-              fullWidth
-              id="newPassword"
-              label="New Password"
-              name="newPassword"
-              type={showPassword ? "text" : "password"}
-              value={newPassword}
-              onChange={handleChange}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton
-                      aria-label="toggle password visibility"
-                      onClick={togglePasswordVisibility}
-                    >
-                      {showPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              }}
-            />
-            <TextField
-              sx={{ mb: 2 }}
-              variant="outlined"
-              margin="normal"
-              required
-              fullWidth
-              id="confirmPassword"
-              label="Confirm Password"
-              name="confirmPassword"
-              type={showConfirmPassword ? "text" : "password"}
-              value={confirmPassword}
-              onChange={handleChange}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton
-                      aria-label="toggle confirm password visibility"
-                      onClick={toggleConfirmPasswordVisibility}
-                    >
-                      {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              }}
-            />
-            <Button
-              type="submit"
-              fullWidth
-              variant="contained"
-              sx={{ mt: 3, mb: 2 }}
-            >
-              Reset Password
-            </Button>
-          </Box>
-        </Paper>
-      </Box>
-    </Container>
+          </Button>
+        </Box>
+      </Paper>
+    </WrapperDiv>
   );
 };
 export default ResetPasswordPage;

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import InputField from "@/components/InputFields";
 import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import { useRouter } from "next/navigation";
-import styles from "./signin-page.module.css";
 import Image from "next/image";
 import mascot from "../../nsc_mascot_green_cropped.png";
+import WrapperDiv from '@/components/WrapperDiv';
 import {
-  Container,
+  Stack,
   Paper,
   Box,
   TextField,
@@ -63,93 +62,84 @@ const Signin = () => {
   };
 
   return (
-    <Container
-      fixed
-      maxWidth="lg"
-      sx={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        bgcolor: "#12202d",
-        height: "100vh",
-        flexDirection: "column",
-      }}
-    >
-      <Image src={mascot} alt="logo" style={{ width: 200, height: 100 }} />
-      <Paper
-        elevation={4}
-        sx={{
-          padding: "20px",
-          width: "400px",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-        }}
-      >
-        <Typography component="h1" variant="h5">
-          Sign In
-        </Typography>
-        <Box
-          component="form"
-          onSubmit={handleSubmit}
-          noValidate
-          sx={{ mt: 1, width: "100%" }}
+    <WrapperDiv>
+      <Stack spacing={{ xs: '-6px', sm: '-6px' }} alignItems="center">
+        <Image src={mascot} alt="logo" style={{ width: 200, height: 100, zIndex: 0 }} />
+        <Paper
+          elevation={4}
+          sx={{
+            padding: "20px",
+            width: "400px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
         >
-          <TextField
-            margin="normal"
-            required
-            fullWidth
-            id="email"
-            label="Email Address"
-            name="email"
-            autoComplete="email"
-            autoFocus
-            value={userInfo.email}
-            onChange={handleChange}
-          />
-          <TextField
-            margin="normal"
-            required
-            fullWidth
-            name="password"
-            label="Password"
-            type="password"
-            id="password"
-            autoComplete="current-password"
-            value={userInfo.password}
-            onChange={handleChange}
-          />
-          {error && (
-            <Typography color="error" textAlign="center">
-              {error}
-            </Typography>
-          )}
-          <Button
-            style={{ textTransform: "none" }}
-            color="primary"
-            type="submit"
-            fullWidth
-            variant="contained"
-            sx={{ mt: 3, mb: 2 }}
-          >
+          <Typography component="h1" variant="h5">
             Sign In
-          </Button>
-          <Box textAlign="center">
-            <MuiLink href="/auth/forgot-password" variant="body2">
-              Forgot password?
-            </MuiLink>
-          </Box>
-          <Box textAlign="center" sx={{ mt: 2 }}>
-            <Typography variant="body2">
-              Don&apos;t have an account?&nbsp;
-              <MuiLink href="/auth/sign-up" variant="body2">
-                {"Sign Up"}
+          </Typography>
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            noValidate
+            sx={{ mt: 1, width: "100%" }}
+          >
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              id="email"
+              label="Email Address"
+              name="email"
+              autoComplete="email"
+              autoFocus
+              value={userInfo.email}
+              onChange={handleChange}
+            />
+            <TextField
+              margin="normal"
+              required
+              fullWidth
+              name="password"
+              label="Password"
+              type="password"
+              id="password"
+              autoComplete="current-password"
+              value={userInfo.password}
+              onChange={handleChange}
+            />
+            {error && (
+              <Typography color="error" textAlign="center">
+                {error}
+              </Typography>
+            )}
+            <Button
+              style={{ textTransform: "none" }}
+              color="primary"
+              type="submit"
+              fullWidth
+              variant="contained"
+              sx={{ mt: 3, mb: 2 }}
+            >
+              Sign In
+            </Button>
+            <Box textAlign="center">
+              <MuiLink href="/auth/forgot-password" variant="body2">
+                Forgot password?
               </MuiLink>
-            </Typography>
+            </Box>
+            <Box textAlign="center" sx={{ mt: 2 }}>
+              <Typography variant="body2">
+                Don&apos;t have an account?&nbsp;
+                <MuiLink href="/auth/sign-up" variant="body2">
+                  {"Sign Up"}
+                </MuiLink>
+              </Typography>
+            </Box>
           </Box>
-        </Box>
-      </Paper>
-    </Container>
+        </Paper>
+      </Stack>
+    </WrapperDiv>
   );
 };
 

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -4,7 +4,6 @@ import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import mascot from "../../nsc_mascot_green_cropped.png";
-import WrapperDiv from '@/components/WrapperDiv';
 import {
   Stack,
   Paper,
@@ -62,84 +61,82 @@ const Signin = () => {
   };
 
   return (
-    <WrapperDiv>
-      <Stack spacing={{ xs: '-6px', sm: '-6px' }} alignItems="center">
-        <Image src={mascot} alt="logo" style={{ width: 200, height: 100, zIndex: 0 }} />
-        <Paper
-          elevation={4}
-          sx={{
-            padding: "20px",
-            width: "400px",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-          }}
+    <Stack spacing={{ xs: '-6px', sm: '-6px' }} alignItems="center">
+      <Image src={mascot} alt="logo" style={{ width: 200, height: 100, zIndex: 0 }} />
+      <Paper
+        elevation={4}
+        sx={{
+          padding: "20px",
+          width: "400px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <Typography component="h1" variant="h5">
+          Sign In
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          noValidate
+          sx={{ mt: 1, width: "100%" }}
         >
-          <Typography component="h1" variant="h5">
-            Sign In
-          </Typography>
-          <Box
-            component="form"
-            onSubmit={handleSubmit}
-            noValidate
-            sx={{ mt: 1, width: "100%" }}
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            id="email"
+            label="Email Address"
+            name="email"
+            autoComplete="email"
+            autoFocus
+            value={userInfo.email}
+            onChange={handleChange}
+          />
+          <TextField
+            margin="normal"
+            required
+            fullWidth
+            name="password"
+            label="Password"
+            type="password"
+            id="password"
+            autoComplete="current-password"
+            value={userInfo.password}
+            onChange={handleChange}
+          />
+          {error && (
+            <Typography color="error" textAlign="center">
+              {error}
+            </Typography>
+          )}
+          <Button
+            style={{ textTransform: "none" }}
+            color="primary"
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
           >
-            <TextField
-              margin="normal"
-              required
-              fullWidth
-              id="email"
-              label="Email Address"
-              name="email"
-              autoComplete="email"
-              autoFocus
-              value={userInfo.email}
-              onChange={handleChange}
-            />
-            <TextField
-              margin="normal"
-              required
-              fullWidth
-              name="password"
-              label="Password"
-              type="password"
-              id="password"
-              autoComplete="current-password"
-              value={userInfo.password}
-              onChange={handleChange}
-            />
-            {error && (
-              <Typography color="error" textAlign="center">
-                {error}
-              </Typography>
-            )}
-            <Button
-              style={{ textTransform: "none" }}
-              color="primary"
-              type="submit"
-              fullWidth
-              variant="contained"
-              sx={{ mt: 3, mb: 2 }}
-            >
-              Sign In
-            </Button>
-            <Box textAlign="center">
-              <MuiLink href="/auth/forgot-password" variant="body2">
-                Forgot password?
-              </MuiLink>
-            </Box>
-            <Box textAlign="center" sx={{ mt: 2 }}>
-              <Typography variant="body2">
-                Don&apos;t have an account?&nbsp;
-                <MuiLink href="/auth/sign-up" variant="body2">
-                  {"Sign Up"}
-                </MuiLink>
-              </Typography>
-            </Box>
+            Sign In
+          </Button>
+          <Box textAlign="center">
+            <MuiLink href="/auth/forgot-password" variant="body2">
+              Forgot password?
+            </MuiLink>
           </Box>
-        </Paper>
-      </Stack>
-    </WrapperDiv>
+          <Box textAlign="center" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Don&apos;t have an account?&nbsp;
+              <MuiLink href="/auth/sign-up" variant="body2">
+                {"Sign Up"}
+              </MuiLink>
+            </Typography>
+          </Box>
+        </Box>
+      </Paper>
+    </Stack>
   );
 };
 

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -4,13 +4,14 @@ import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
 import { IconButton, InputAdornment, TextField } from "@mui/material";
-import { Box, Button, Container, Paper, Typography } from "@mui/material";
+import { Box, Button, Paper, Typography, Stack } from "@mui/material";
 import Image from "next/image";
 import mascot from "../../nsc_mascot_green_cropped.png";
 import { Link as MuiLink } from "@mui/material";
 import ErrorAlert from "@/components/ErrorAlert";
 import SuccessAlert from "@/components/SuccessAlert";
 import { useRouter } from "next/navigation";
+import WrapperDiv from '@/components/WrapperDiv';
 
 const SignUp = () => {
   // handling user's incoming info
@@ -107,147 +108,138 @@ const SignUp = () => {
   };
 
   return (
-    <Container
-      fixed
-      maxWidth="lg"
-      sx={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        bgcolor: "#12202d",
-        height: "100vh",
-        flexDirection: "column",
-      }}
-    >
-      <Image src={mascot} alt="logo" style={{ width: 200, height: 100 }} />
-      <Paper
-        elevation={4}
-        sx={{
-          padding: "20px",
-          width: "400px",
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-        }}
-      >
-        <Typography component="h1" variant="h5">
-          Sign Up
-        </Typography>
-        <Box
-          component="form"
-          onSubmit={handleSubmit}
-          noValidate
-          sx={{ mt: 1, width: "100%" }}
+    <WrapperDiv>
+      <Stack spacing={{ xs: '-6px', sm: '-6px' }} alignItems="center">
+        <Image src={mascot} alt="logo" style={{ width: 200, height: 100, zIndex: 0 }} />
+        <Paper
+          elevation={4}
+          sx={{
+            padding: "20px",
+            width: "400px",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}
         >
-          <TextField
-            sx={{ mb: 2 }}
-            margin="normal"
-            required
-            fullWidth
-            id="firstName"
-            label="First Name"
-            name="firstName"
-            autoComplete="fname"
-            autoFocus
-            value={firstName}
-            onChange={handleChange}
-          />
-          <TextField
-            sx={{ mb: 2 }}
-            margin="normal"
-            required
-            fullWidth
-            id="lastName"
-            label="Last Name"
-            name="lastName"
-            autoComplete="lname"
-            value={lastName}
-            onChange={handleChange}
-            autoFocus={false}
-          />
-          <TextField
-            sx={{ mb: 2 }}
-            margin="normal"
-            required
-            fullWidth
-            id="email"
-            label="Email Address"
-            name="email"
-            autoComplete="email"
-            value={email}
-            onChange={handleChange}
-            type="email"
-            autoFocus={false}
-          />
-          <TextField
-            sx={{ mb: 2 }}
-            margin="normal"
-            required
-            fullWidth
-            id="password"
-            label="Password"
-            name="password"
-            type={showPassword ? "text" : "password"}
-            autoComplete="password"
-            value={password}
-            onChange={handleChange}
-            autoFocus={false}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton onClick={togglePasswordVisibility}>
-                    {showPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-          <TextField
-            sx={{ mb: 2 }}
-            margin="normal"
-            required
-            fullWidth
-            id="confirmPassword"
-            label="Confirm Password"
-            name="confirmPassword"
-            type={showConfirmPassword ? "text" : "password"}
-            autoComplete="confirm-password"
-            value={confirmPassword}
-            onChange={handleChange}
-            autoFocus={false}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton onClick={toggleConfirmPasswordVisibility}>
-                    {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
-                  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-          {error && <ErrorAlert message={error} />}
-          {success && <SuccessAlert message={success} />}
-          <Button
-            style={{ textTransform: "none" }}
-            color="primary"
-            type="submit"
-            fullWidth
-            variant="contained"
-            sx={{ mt: 3, mb: 2 }}
-          >
+          <Typography component="h1" variant="h5">
             Sign Up
-          </Button>
-          <Box textAlign="center" sx={{ mt: 2 }}>
-            <Typography variant="body2">
-              Already have an account?{" "}
-              <MuiLink href="/auth/sign-up" variant="body2">
-                {"Sign In"}
-              </MuiLink>
-            </Typography>
+          </Typography>
+          <Box
+            component="form"
+            onSubmit={handleSubmit}
+            noValidate
+            sx={{ mt: 1, width: "100%" }}
+          >
+            <TextField
+              sx={{ mb: 2 }}
+              margin="normal"
+              required
+              fullWidth
+              id="firstName"
+              label="First Name"
+              name="firstName"
+              autoComplete="fname"
+              autoFocus
+              value={firstName}
+              onChange={handleChange}
+            />
+            <TextField
+              sx={{ mb: 2 }}
+              margin="normal"
+              required
+              fullWidth
+              id="lastName"
+              label="Last Name"
+              name="lastName"
+              autoComplete="lname"
+              value={lastName}
+              onChange={handleChange}
+              autoFocus={false}
+            />
+            <TextField
+              sx={{ mb: 2 }}
+              margin="normal"
+              required
+              fullWidth
+              id="email"
+              label="Email Address"
+              name="email"
+              autoComplete="email"
+              value={email}
+              onChange={handleChange}
+              type="email"
+              autoFocus={false}
+            />
+            <TextField
+              sx={{ mb: 2 }}
+              margin="normal"
+              required
+              fullWidth
+              id="password"
+              label="Password"
+              name="password"
+              type={showPassword ? "text" : "password"}
+              autoComplete="password"
+              value={password}
+              onChange={handleChange}
+              autoFocus={false}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={togglePasswordVisibility}>
+                      {showPassword ? <Visibility /> : <VisibilityOff />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+            <TextField
+              sx={{ mb: 2 }}
+              margin="normal"
+              required
+              fullWidth
+              id="confirmPassword"
+              label="Confirm Password"
+              name="confirmPassword"
+              type={showConfirmPassword ? "text" : "password"}
+              autoComplete="confirm-password"
+              value={confirmPassword}
+              onChange={handleChange}
+              autoFocus={false}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton onClick={toggleConfirmPasswordVisibility}>
+                      {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              }}
+            />
+            {error && <ErrorAlert message={error} />}
+            {success && <SuccessAlert message={success} />}
+            <Button
+              style={{ textTransform: "none" }}
+              color="primary"
+              type="submit"
+              fullWidth
+              variant="contained"
+              sx={{ mt: 3, mb: 2 }}
+            >
+              Sign Up
+            </Button>
+            <Box textAlign="center" sx={{ mt: 2 }}>
+              <Typography variant="body2">
+                Already have an account?{" "}
+                <MuiLink href="/auth/sign-up" variant="body2">
+                  {"Sign In"}
+                </MuiLink>
+              </Typography>
+            </Box>
           </Box>
-        </Box>
-      </Paper>
-    </Container>
+        </Paper>
+      </Stack>
+    </WrapperDiv>
   );
 };
 

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -11,7 +11,6 @@ import { Link as MuiLink } from "@mui/material";
 import ErrorAlert from "@/components/ErrorAlert";
 import SuccessAlert from "@/components/SuccessAlert";
 import { useRouter } from "next/navigation";
-import WrapperDiv from '@/components/WrapperDiv';
 
 const SignUp = () => {
   // handling user's incoming info
@@ -108,138 +107,136 @@ const SignUp = () => {
   };
 
   return (
-    <WrapperDiv>
-      <Stack spacing={{ xs: '-6px', sm: '-6px' }} alignItems="center">
-        <Image src={mascot} alt="logo" style={{ width: 200, height: 100, zIndex: 0 }} />
-        <Paper
-          elevation={4}
-          sx={{
-            padding: "20px",
-            width: "400px",
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-          }}
+    <Stack spacing={{ xs: '-6px', sm: '-6px' }} alignItems="center">
+      <Image src={mascot} alt="logo" style={{ width: 200, height: 100, zIndex: 0 }} />
+      <Paper
+        elevation={4}
+        sx={{
+          padding: "20px",
+          width: "400px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+        }}
+      >
+        <Typography component="h1" variant="h5">
+          Sign Up
+        </Typography>
+        <Box
+          component="form"
+          onSubmit={handleSubmit}
+          noValidate
+          sx={{ mt: 1, width: "100%" }}
         >
-          <Typography component="h1" variant="h5">
-            Sign Up
-          </Typography>
-          <Box
-            component="form"
-            onSubmit={handleSubmit}
-            noValidate
-            sx={{ mt: 1, width: "100%" }}
+          <TextField
+            sx={{ mb: 2 }}
+            margin="normal"
+            required
+            fullWidth
+            id="firstName"
+            label="First Name"
+            name="firstName"
+            autoComplete="fname"
+            autoFocus
+            value={firstName}
+            onChange={handleChange}
+          />
+          <TextField
+            sx={{ mb: 2 }}
+            margin="normal"
+            required
+            fullWidth
+            id="lastName"
+            label="Last Name"
+            name="lastName"
+            autoComplete="lname"
+            value={lastName}
+            onChange={handleChange}
+            autoFocus={false}
+          />
+          <TextField
+            sx={{ mb: 2 }}
+            margin="normal"
+            required
+            fullWidth
+            id="email"
+            label="Email Address"
+            name="email"
+            autoComplete="email"
+            value={email}
+            onChange={handleChange}
+            type="email"
+            autoFocus={false}
+          />
+          <TextField
+            sx={{ mb: 2 }}
+            margin="normal"
+            required
+            fullWidth
+            id="password"
+            label="Password"
+            name="password"
+            type={showPassword ? "text" : "password"}
+            autoComplete="password"
+            value={password}
+            onChange={handleChange}
+            autoFocus={false}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton onClick={togglePasswordVisibility}>
+                    {showPassword ? <Visibility /> : <VisibilityOff />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+            sx={{ mb: 2 }}
+            margin="normal"
+            required
+            fullWidth
+            id="confirmPassword"
+            label="Confirm Password"
+            name="confirmPassword"
+            type={showConfirmPassword ? "text" : "password"}
+            autoComplete="confirm-password"
+            value={confirmPassword}
+            onChange={handleChange}
+            autoFocus={false}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton onClick={toggleConfirmPasswordVisibility}>
+                    {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+          {error && <ErrorAlert message={error} />}
+          {success && <SuccessAlert message={success} />}
+          <Button
+            style={{ textTransform: "none" }}
+            color="primary"
+            type="submit"
+            fullWidth
+            variant="contained"
+            sx={{ mt: 3, mb: 2 }}
           >
-            <TextField
-              sx={{ mb: 2 }}
-              margin="normal"
-              required
-              fullWidth
-              id="firstName"
-              label="First Name"
-              name="firstName"
-              autoComplete="fname"
-              autoFocus
-              value={firstName}
-              onChange={handleChange}
-            />
-            <TextField
-              sx={{ mb: 2 }}
-              margin="normal"
-              required
-              fullWidth
-              id="lastName"
-              label="Last Name"
-              name="lastName"
-              autoComplete="lname"
-              value={lastName}
-              onChange={handleChange}
-              autoFocus={false}
-            />
-            <TextField
-              sx={{ mb: 2 }}
-              margin="normal"
-              required
-              fullWidth
-              id="email"
-              label="Email Address"
-              name="email"
-              autoComplete="email"
-              value={email}
-              onChange={handleChange}
-              type="email"
-              autoFocus={false}
-            />
-            <TextField
-              sx={{ mb: 2 }}
-              margin="normal"
-              required
-              fullWidth
-              id="password"
-              label="Password"
-              name="password"
-              type={showPassword ? "text" : "password"}
-              autoComplete="password"
-              value={password}
-              onChange={handleChange}
-              autoFocus={false}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton onClick={togglePasswordVisibility}>
-                      {showPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              }}
-            />
-            <TextField
-              sx={{ mb: 2 }}
-              margin="normal"
-              required
-              fullWidth
-              id="confirmPassword"
-              label="Confirm Password"
-              name="confirmPassword"
-              type={showConfirmPassword ? "text" : "password"}
-              autoComplete="confirm-password"
-              value={confirmPassword}
-              onChange={handleChange}
-              autoFocus={false}
-              InputProps={{
-                endAdornment: (
-                  <InputAdornment position="end">
-                    <IconButton onClick={toggleConfirmPasswordVisibility}>
-                      {showConfirmPassword ? <Visibility /> : <VisibilityOff />}
-                    </IconButton>
-                  </InputAdornment>
-                ),
-              }}
-            />
-            {error && <ErrorAlert message={error} />}
-            {success && <SuccessAlert message={success} />}
-            <Button
-              style={{ textTransform: "none" }}
-              color="primary"
-              type="submit"
-              fullWidth
-              variant="contained"
-              sx={{ mt: 3, mb: 2 }}
-            >
-              Sign Up
-            </Button>
-            <Box textAlign="center" sx={{ mt: 2 }}>
-              <Typography variant="body2">
-                Already have an account?{" "}
-                <MuiLink href="/auth/sign-up" variant="body2">
-                  {"Sign In"}
-                </MuiLink>
-              </Typography>
-            </Box>
+            Sign Up
+          </Button>
+          <Box textAlign="center" sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Already have an account?{" "}
+              <MuiLink href="/auth/sign-up" variant="body2">
+                {"Sign In"}
+              </MuiLink>
+            </Typography>
           </Box>
-        </Paper>
-      </Stack>
-    </WrapperDiv>
+        </Box>
+      </Paper>
+    </Stack>
   );
 };
 

--- a/app/category-page/[categoryId]/page.tsx
+++ b/app/category-page/[categoryId]/page.tsx
@@ -4,7 +4,6 @@ import React, { useState, useEffect, Dispatch, SetStateAction } from "react";
 import ProductCard from "@/components/ProductCard";
 import logo from "../../logo.png";
 import { Container, Grid, Typography } from "@mui/material";
-import WrapperDiv from '@/components/WrapperDiv'
 const placeholderImg = logo;
 interface Product {
   _id: string;
@@ -102,8 +101,6 @@ export default function ProductList({
   const decodedCategoryId = decodeURIComponent(params.categoryId);
 
   return (
-    <WrapperDiv>
       <ViewProduct categoryId={decodedCategoryId} />
-    </WrapperDiv>
   );
 }

--- a/app/category-page/[categoryId]/page.tsx
+++ b/app/category-page/[categoryId]/page.tsx
@@ -4,6 +4,7 @@ import React, { useState, useEffect, Dispatch, SetStateAction } from "react";
 import ProductCard from "@/components/ProductCard";
 import logo from "../../logo.png";
 import { Container, Grid, Typography } from "@mui/material";
+import WrapperDiv from '@/components/WrapperDiv'
 const placeholderImg = logo;
 interface Product {
   _id: string;
@@ -60,48 +61,37 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
   }, [products]);
 
   return (
-    <Container
-      fixed
-      maxWidth="lg"
-      sx={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        bgcolor: "#12202d",
-      }}
-    >
-      <Container sx={{ py: 4 }} maxWidth="lg">
-        <Typography
-          variant="h4"
-          gutterBottom
-          justifyContent={"center"}
-          align={"center"}
-        >
-          Found {filteredProducts.length} products in {categoryId}
-        </Typography>
-        <Grid container spacing={2}>
-          {filteredProducts.map((product, index) => (
-            <Grid item key={index} xs={12} sm={6} md={4}>
-              <ProductCard
-                image={logo}
-                categories={product.productType}
-                gender={product.productGender}
-                sizeShoe={product.productSizeShoe}
-                size={product.productSizes}
-                sizePantsWaist={product.productSizePantsWaist}
-                sizePantsInseam={product.productSizePantsInseam}
-                description={product.productDescription}
-                href={`/category-page/${categoryId}/products/${product._id}`} // Construct the URL            
-                _id={product._id} 
-                isHidden={false} 
-                isSold={false}              
-              />
-            </Grid>
-          ))}
-        </Grid>
-      </Container>
+    <Container sx={{ py: 4 }} maxWidth="lg">
+      <Typography
+        variant="h4"
+        gutterBottom
+        justifyContent={"center"}
+        align={"center"}
+      >
+        Found {filteredProducts.length} products in {categoryId}
+      </Typography>
+      <Grid container spacing={2}>
+        {filteredProducts.map((product, index) => (
+          <Grid item key={index} xs={12} sm={6} md={4}>
+            <ProductCard
+              image={logo}
+              categories={product.productType}
+              gender={product.productGender}
+              sizeShoe={product.productSizeShoe}
+              size={product.productSizes}
+              sizePantsWaist={product.productSizePantsWaist}
+              sizePantsInseam={product.productSizePantsInseam}
+              description={product.productDescription}
+              href={`/category-page/${categoryId}/products/${product._id}`} // Construct the URL            
+              _id={product._id} 
+              isHidden={false} 
+              isSold={false}              
+            />
+          </Grid>
+        ))}
+      </Grid>
     </Container>
-  );
+);
 };
 
 export default function ProductList({
@@ -112,8 +102,8 @@ export default function ProductList({
   const decodedCategoryId = decodeURIComponent(params.categoryId);
 
   return (
-    <Container>
+    <WrapperDiv>
       <ViewProduct categoryId={decodedCategoryId} />
-    </Container>
+    </WrapperDiv>
   );
 }

--- a/app/category-page/[categoryId]/products/[productId]/ProductDetailDisplay.tsx
+++ b/app/category-page/[categoryId]/products/[productId]/ProductDetailDisplay.tsx
@@ -15,6 +15,7 @@ import ArchiveIcon from "@mui/icons-material/Archive";
 import ConfirmDeleteDialog from "@/components/ConfirmDeleteDialog";
 import ConfirmArchiveDialog from "@/components/ConfirmArchiveDialog";
 import EditProductDialog from "@/components/EditProductDialog";
+import WrapperDiv from '@/components/WrapperDiv';
 
 export interface Product {
   _id: string;
@@ -46,7 +47,7 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
   }, []);
 
   if (!product) {
-    return <div>Loading...</div>;
+    return <WrapperDiv>Loading...</WrapperDiv>;
   }
 
   const handleDeleteButtonClick = () => {
@@ -74,133 +75,115 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
   };
 
   return (
-    <Container
-      fixed
-      maxWidth="lg"
-      sx={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        bgcolor: "#12202d",
-      }}
-    >
-      <Box
-        width={800}
-        display="flex"
-        alignItems="center"
-        flexDirection="column"
-        gap={2}
-        p={3}
-      >
-        <Typography component="h1" variant="h4">
-          {product && product.productType}
-        </Typography>
-        <Paper elevation={3}>
-          <Box p={2} m={2}>
-            {product && (
-              <Stack direction="column" spacing={2} justifyContent="center">
-                <Box
-                  display="flex"
-                  flexDirection="column"
-                  gap={2}
-                  alignItems="flex-start"
-                >
-                  <Typography variant="h6">
-                    Product ID: {product._id}
-                  </Typography>
-                  <Typography variant="h6">
-                    Product Type: {product.productType}
-                  </Typography>
-                  <Typography variant="h6">
-                    Product Gender: {product.productGender}
-                  </Typography>
-                  <Typography variant="h6">
-                    Product Shoe Size: {product.productSizeShoe || "N/A"}
-                  </Typography>
-                  <Typography variant="h6">
-                    Product Size: {product.productSizes || "N/A"}
-                  </Typography>
-                  <Typography variant="h6">
-                    Product Size Pants Waist:{" "}
-                    {product.productSizePantsWaist || "N/A"}
-                  </Typography>
-                  <Typography variant="h6">
-                    Product Size Pants Inseam:{" "}
-                    {product.productSizePantsInseam || "N/A"}
-                  </Typography>
-                  <Typography variant="h6">
-                    Product Description: {product.productDescription || "N/A"}
-                  </Typography>
-                </Box>
-                <Box display="flex" justifyContent="center">
-                  <Image
-                    src={logo} // temporary image
-                    alt="Product Image"
-                    width={250}
-                    height={250}
-                    style={{ borderRadius: "5px", marginTop: "10px" }}
-                  />
-                </Box>
-              </Stack>
-            )}
+    <WrapperDiv>
+      <Typography component="h1" variant="h4">
+        {product && product.productType}
+      </Typography>
+      <Paper elevation={3}>
+        <Box p={2} m={2}>
+          {product && (
+            <Stack direction="column" spacing={2} justifyContent="center">
+              <Box
+                display="flex"
+                flexDirection="column"
+                gap={2}
+                alignItems="flex-start"
+              >
+                <Typography variant="h6">
+                  Product ID: {product._id}
+                </Typography>
+                <Typography variant="h6">
+                  Product Type: {product.productType}
+                </Typography>
+                <Typography variant="h6">
+                  Product Gender: {product.productGender}
+                </Typography>
+                <Typography variant="h6">
+                  Product Shoe Size: {product.productSizeShoe || "N/A"}
+                </Typography>
+                <Typography variant="h6">
+                  Product Size: {product.productSizes || "N/A"}
+                </Typography>
+                <Typography variant="h6">
+                  Product Size Pants Waist:{" "}
+                  {product.productSizePantsWaist || "N/A"}
+                </Typography>
+                <Typography variant="h6">
+                  Product Size Pants Inseam:{" "}
+                  {product.productSizePantsInseam || "N/A"}
+                </Typography>
+                <Typography variant="h6">
+                  Product Description: {product.productDescription || "N/A"}
+                </Typography>
+              </Box>
+              <Box display="flex" justifyContent="center">
+                <Image
+                  src={logo} // temporary image
+                  alt="Product Image"
+                  width={250}
+                  height={250}
+                  style={{ borderRadius: "5px", marginTop: "10px" }}
+                />
+              </Box>
+            </Stack>
+          )}
+        </Box>
+
+        {userRole === "admin" || userRole === "creator" ? (
+        <Stack direction="row" spacing={2} justifyContent="center">
+          {/* Edit Button */}
+          <Box p={2} display="flex" justifyContent="center">
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<EditIcon />}
+              onClick={handleEditButtonClick}
+            >
+              Edit
+            </Button>
           </Box>
+          {/* Delete Button */}
+          <Box p={2} display="flex" justifyContent="center">
+            <Button
+              variant="contained"
+              color="error"
+              startIcon={<DeleteIcon />}
+              onClick={handleDeleteButtonClick}
+            >
+              Delete
+            </Button>
+          </Box>
+          {/* Archive Button */}
+          <Box p={2} display="flex" justifyContent="center">
+            <Button
+              variant="contained"
+              color="warning"
+              startIcon={<ArchiveIcon />}
+              onClick={handleArchiveButtonClick}
+            >
+              Archive
+            </Button>
+          </Box>
+        </Stack>
+          ) : null}
 
-          {userRole === "admin" || userRole === "creator" ? (
-          <Stack direction="row" spacing={2} justifyContent="center">
-            {/* Edit Button */}
-            <Box p={2} display="flex" justifyContent="center">
-              <Button
-                variant="contained"
-                color="primary"
-                startIcon={<EditIcon />}
-                onClick={handleEditButtonClick}
-              >
-                Edit
-              </Button>
-            </Box>
-            {/* Delete Button */}
-            <Box p={2} display="flex" justifyContent="center">
-              <Button
-                variant="contained"
-                color="error"
-                startIcon={<DeleteIcon />}
-                onClick={handleDeleteButtonClick}
-              >
-                Delete
-              </Button>
-            </Box>
-            {/* Archive Button */}
-            <Box p={2} display="flex" justifyContent="center">
-              <Button
-                variant="contained"
-                color="warning"
-                startIcon={<ArchiveIcon />}
-                onClick={handleArchiveButtonClick}
-              >
-                Archive
-              </Button>
-            </Box>
-          </Stack>
-           ) : null}
-
-            <EditProductDialog
-              open={openEditDialog}
-              onClose={handleCloseEditDialog}
-              product={product}
-            />
-            <ConfirmDeleteDialog
-              open={openDeleteDialog}
-              onClose={handleCloseDeleteDialog}
-              product={product}
-            />
-            <ConfirmArchiveDialog
-              open={openArchiveDialog}
-              onClose={handleCloseArchiveDialog}
-              product={product}
-            />
-        </Paper>
-      </Box>
-    </Container>
+          <EditProductDialog
+            open={openEditDialog}
+            onClose={handleCloseEditDialog}
+            product={product}
+          />
+          <ConfirmDeleteDialog
+            open={openDeleteDialog}
+            onClose={handleCloseDeleteDialog}
+            product={product}
+          />
+          <ConfirmArchiveDialog
+            open={openArchiveDialog}
+            onClose={handleCloseArchiveDialog}
+            product={product}
+          />
+      </Paper>
+    </WrapperDiv>
   );
 };
 

--- a/app/category-page/[categoryId]/products/[productId]/ProductDetailDisplay.tsx
+++ b/app/category-page/[categoryId]/products/[productId]/ProductDetailDisplay.tsx
@@ -4,7 +4,6 @@ import logo from "app/logo.png";
 import {
   Box,
   Button,
-  Container,
   Paper,
   Stack,
   Typography,
@@ -15,7 +14,6 @@ import ArchiveIcon from "@mui/icons-material/Archive";
 import ConfirmDeleteDialog from "@/components/ConfirmDeleteDialog";
 import ConfirmArchiveDialog from "@/components/ConfirmArchiveDialog";
 import EditProductDialog from "@/components/EditProductDialog";
-import WrapperDiv from '@/components/WrapperDiv';
 
 export interface Product {
   _id: string;
@@ -47,7 +45,7 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
   }, []);
 
   if (!product) {
-    return <WrapperDiv>Loading...</WrapperDiv>;
+    return <Typography>Loading...</Typography>;
   }
 
   const handleDeleteButtonClick = () => {
@@ -75,7 +73,7 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
   };
 
   return (
-    <WrapperDiv>
+    <Stack>
       <Typography component="h1" variant="h4">
         {product && product.productType}
       </Typography>
@@ -183,7 +181,7 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
             product={product}
           />
       </Paper>
-    </WrapperDiv>
+    </Stack>
   );
 };
 

--- a/app/category-page/[categoryId]/products/[productId]/page.tsx
+++ b/app/category-page/[categoryId]/products/[productId]/page.tsx
@@ -5,7 +5,6 @@ import {
   CircularProgress,
 } from "@mui/material";
 import ProductDetailDisplay from "../[productId]/ProductDetailDisplay";
-import WrapperDiv from '@/components/WrapperDiv';
 
 interface Product {
   _id: string;
@@ -64,9 +63,7 @@ const ProductDetail = ({
 
   if (isLoading)
     return (
-      <WrapperDiv>
-        <CircularProgress />
-      </WrapperDiv>
+      <CircularProgress />
     );
   if (error) return <div>Error: {error}</div>;
 

--- a/app/category-page/[categoryId]/products/[productId]/page.tsx
+++ b/app/category-page/[categoryId]/products/[productId]/page.tsx
@@ -2,10 +2,10 @@
 
 import React, { useState, useEffect } from "react";
 import {
-  Box,
   CircularProgress,
 } from "@mui/material";
 import ProductDetailDisplay from "../[productId]/ProductDetailDisplay";
+import WrapperDiv from '@/components/WrapperDiv';
 
 interface Product {
   _id: string;
@@ -64,9 +64,9 @@ const ProductDetail = ({
 
   if (isLoading)
     return (
-      <Box sx={{ display: "flex", justifyContent: "center" }}>
+      <WrapperDiv>
         <CircularProgress />
-      </Box>
+      </WrapperDiv>
     );
   if (error) return <div>Error: {error}</div>;
 

--- a/app/creator-page/page.tsx
+++ b/app/creator-page/page.tsx
@@ -1,8 +1,7 @@
-import WrapperDiv from '@/components/WrapperDiv';
 const Creator = () => {
     // Temporary boilerplate code to make it compile
     return (
-        <WrapperDiv>
+        <div>
        
         <div >
             <div>
@@ -21,7 +20,7 @@ const Creator = () => {
 
             <h1>Placeholder creators page.</h1>
             <p>Place holder text to fill in the space.</p>
-        </WrapperDiv>
+        </div>
     );
 };
 

--- a/app/creator-page/page.tsx
+++ b/app/creator-page/page.tsx
@@ -1,7 +1,8 @@
+import WrapperDiv from '@/components/WrapperDiv';
 const Creator = () => {
     // Temporary boilerplate code to make it compile
     return (
-        <div className="flex flex-col items-center justify-center min-h-screen">
+        <WrapperDiv>
        
         <div >
             <div>
@@ -20,7 +21,7 @@ const Creator = () => {
 
             <h1>Placeholder creators page.</h1>
             <p>Place holder text to fill in the space.</p>
-        </div>
+        </WrapperDiv>
     );
 };
 

--- a/app/donation-info/page.tsx
+++ b/app/donation-info/page.tsx
@@ -1,11 +1,8 @@
-import WrapperDiv from '@/components/WrapperDiv';
 import {Typography} from '@mui/material';
 
 const DonationInfo=()=>{
     return (
-        <WrapperDiv>
             <Typography component='h1' variant='h3' sx={{color: 'white'}}>Donation Info</Typography>
-        </WrapperDiv>
     )
 }
 

--- a/app/donation-info/page.tsx
+++ b/app/donation-info/page.tsx
@@ -1,11 +1,11 @@
-import Box from '@mui/material/Box';
+import WrapperDiv from '@/components/WrapperDiv';
 import {Typography} from '@mui/material';
 
 const DonationInfo=()=>{
     return (
-        <Box width={800} display="flex" alignItems="center" flexDirection="column" gap={2} bgcolor='#293745' p={3}>
+        <WrapperDiv>
             <Typography component='h1' variant='h3' sx={{color: 'white'}}>Donation Info</Typography>
-        </Box>
+        </WrapperDiv>
     )
 }
 

--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react";
 import UserCard from "../../components/UserCard";
 import { Box, Container, Typography } from "@mui/material";
+import WrapperDiv from '@/components/WrapperDiv';
 
 /**
  * Represents a user.
@@ -50,33 +51,14 @@ const EditUserRolePage = () => {
   }, []);
 
   return (
-    <Container
-      fixed
-      maxWidth="lg"
-      sx={{
-        display: "flex",
-        justifyContent: "center",
-        alignItems: "center",
-        bgcolor: "#12202d",
-      }}
-    >
-      <Box
-        width={800}
-        display="flex"
-        alignItems="center"
-        flexDirection="column"
-        gap={2}
-        bgcolor="#293745"
-        p={3}
-      >
+      <WrapperDiv>
         <Typography component="h1" variant="h4">
           User Management
         </Typography>
         {userInfo.map((user, index) => (
           <UserCard user={user} key={index} />
         ))}
-      </Box>
-    </Container>
+      </WrapperDiv>
   );
 };
 

--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 import React, { useState, useEffect } from "react";
 import UserCard from "../../components/UserCard";
-import { Box, Container, Typography } from "@mui/material";
-import WrapperDiv from '@/components/WrapperDiv';
+import { Stack, Typography } from "@mui/material";
 
 /**
  * Represents a user.
@@ -51,14 +50,14 @@ const EditUserRolePage = () => {
   }, []);
 
   return (
-      <WrapperDiv>
+      <Stack>
         <Typography component="h1" variant="h4">
           User Management
         </Typography>
         {userInfo.map((user, index) => (
           <UserCard user={user} key={index} />
         ))}
-      </WrapperDiv>
+      </Stack>
   );
 };
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,10 @@ export default function RootLayout({
       <html lang="en">
         <body>
           <SessionProvider>
-            <Navbar/>{children}
+            <Navbar/>
+            <WrapperDiv>
+              {children}
+            </WrapperDiv>
           </SessionProvider>
         </body>
       </html>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,7 @@ import SessionProvider from '@/components/SessionProvider';
 import { ThemeProvider } from "@mui/material/styles";
 import theme from './theme/theme';
 import CssBaseline from "@mui/material/CssBaseline";
-
+import WrapperDiv from '../components/WrapperDiv'
 
 const inter = Inter({ subsets: ['latin'] })
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,10 +5,10 @@ import logo from "./logo.png";
 import google_play from "./google_play.png";
 import CustomCardContent from "@/components/CustomCardContent";
 import Grid from '@mui/material/Unstable_Grid2';
-import Box from '@mui/material/Box';
 import Stack from '@mui/material/Stack';
 import Card from '@mui/material/Card';
 import { Container, Typography, Button } from '@mui/material';
+import WrapperDiv from '../components/WrapperDiv'
 
 // TEMPORARY CATEGORIES LIST
 const placeholderImg = logo;
@@ -26,33 +26,31 @@ const categories = [
 
 const Home = () => {
   return (
-    <Box bgcolor='#12202d' display="flex" alignItems="center" flexDirection="column">
-      <Box width={800} display="flex" alignItems="center" flexDirection="column" gap={2} bgcolor='#293745' p={3}>
-        <Container disableGutters fixed maxWidth="xs" sx={{width: "15%"}}>
-          <Image src={logo} alt="logo" width={100} />
-        </Container>
-        <Typography component='h1' variant='h3' sx={{color: 'white'}}>
-          Belinda&apos;s Closet
-        </Typography>
-        <Stack direction="row" spacing={2}>
-          <Button href="/auth/sign-in" component='a' variant="contained">Sign In</Button>
-          <Button href="/auth/sign-up" component='a' variant="contained">Sign Up</Button>
-        </Stack>
-        {/* download mobile app link */}
-        <Button component='a' href="" variant="outlined" startIcon={<Image src={google_play} alt="google_play" />} sx={{color:'white' }}>
-          Download App
-        </Button>
-          <Grid container spacing={2}>
-              {categories.map((category, index)=>(
-                <Grid xs={12} md={6} lg={4} component="div" key={index}>
-                  <Card>
-                    <CustomCardContent title={category.type} image={placeholderImg} />
-                  </Card>
-                </Grid>
-              ))}
-          </Grid>
-        </Box>
-    </Box>
+    <WrapperDiv>
+      <Container disableGutters fixed maxWidth="xs" sx={{width: "15%"}}>
+        <Image src={logo} alt="logo" width={100} />
+      </Container>
+      <Typography component='h1' variant='h3' sx={{color: 'white'}}>
+        Belinda&apos;s Closet
+      </Typography>
+      <Stack direction="row" spacing={2}>
+        <Button href="/auth/sign-in" component='a' variant="contained">Sign In</Button>
+        <Button href="/auth/sign-up" component='a' variant="contained">Sign Up</Button>
+      </Stack>
+      {/* download mobile app link */}
+      <Button component='a' href="" variant="outlined" startIcon={<Image src={google_play} alt="google_play" />} sx={{color:'white' }}>
+        Download App
+      </Button>
+        <Grid container spacing={2}>
+            {categories.map((category, index)=>(
+              <Grid xs={12} md={6} lg={4} component="div" key={index}>
+                <Card>
+                  <CustomCardContent title={category.type} image={placeholderImg} />
+                </Card>
+              </Grid>
+            ))}
+        </Grid>
+      </WrapperDiv>
   );
 };
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,12 +1,10 @@
-import WrapperDiv from '@/components/WrapperDiv';
-
 const Profile = () => {
     // Temporary boilerplate code to make it compile
     return (
-        <WrapperDiv>
+        <div>
             <h1>Placeholder Profile so npm run build compiles successfully.</h1>
             <p>FIX: move to pages or use getSession from nextauth</p>
-        </WrapperDiv>
+        </div>
     );
 };
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,11 +1,12 @@
+import WrapperDiv from '@/components/WrapperDiv';
 
 const Profile = () => {
     // Temporary boilerplate code to make it compile
     return (
-        <div className="flex flex-col items-center justify-center min-h-screen">
+        <WrapperDiv>
             <h1>Placeholder Profile so npm run build compiles successfully.</h1>
             <p>FIX: move to pages or use getSession from nextauth</p>
-        </div>
+        </WrapperDiv>
     );
 };
 

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -100,7 +100,7 @@ export default function ProductCard({
           theme.palette.mode === "dark" ? "#1A2027" : "#fff",
       }}
     >
-      <Grid container spacing={2}>
+      <Grid container spacing={2}  justifyContent="center">
         <Grid item>
           <ButtonBase>
             <Link href={href}>
@@ -140,8 +140,8 @@ export default function ProductCard({
           </Grid>
         </Grid>
       </Grid>
-      <Stack direction="row" spacing={2} justifyContent="flex-end" mt={2}>
-        <Button variant="contained" href={href} color="primary">
+      <Stack direction="column" spacing={2} justifyContent="flex-end" mt={2}>
+        <Button variant="contained" href={href} color="primary"  sx={{minWidth: 30, maxWidth: "215px"}}>
           View
         </Button>
         
@@ -149,11 +149,11 @@ export default function ProductCard({
             (
               <Stack direction="row" spacing={2}>
                 {/* TODO: Add delete function to this button  */}
-                <Button variant="contained" startIcon={<DeleteIcon />} color="error" onClick={() => handleDelete()}>
+                <Button variant="contained" startIcon={<DeleteIcon />} color="error" onClick={() => handleDelete()} sx={{fontSize: 10}}>
                   Delete
                 </Button>
                 {/* TODO: Add archive function to this button  */}
-                <Button variant="contained" startIcon={<ArchiveIcon />} color="warning" onClick={() => handleArchive()}>
+                <Button variant="contained" startIcon={<ArchiveIcon />} color="warning" onClick={() => handleArchive()} sx={{fontSize: 10}}>
                   Archive
                 </Button>
               </Stack>

--- a/components/WrapperDiv.tsx
+++ b/components/WrapperDiv.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Box, BoxProps } from "@mui/material";
+
+const styles = {
+    width: 800,
+    bgcolor: '#293745',
+    minHeight: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+    gap: 2,
+    p: 3
+}
+
+
+const CustomCardContent: React.FC<BoxProps> =({children})=>{
+    return (
+        <Box sx={styles}>
+            {children}
+        </Box>
+    )
+}
+
+export default CustomCardContent;


### PR DESCRIPTION
1.  I created a custom Box component to use as the center div wrapper on every page. Now it should be easier to change the general layout of the site going forward.
Code:
![customBox](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91910852/d5e588e3-9152-4265-984b-1a063995c674)
Example (The dark grey square in the center):
![signinfrog](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91910852/a1d3ada3-9b6c-43fa-ac17-12cbf2494931)

2. I wrapped every page in the new WrapperDiv component
Example code:
![wrapper example](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91910852/675e8d33-c252-4d72-b79d-478e8363c913)

3. This is a little extra thing I did but I also brought the frog closer to (and slightly overlapping) the forms on the sign up and sign in page as you can see in the picture above as well as here:
![signupfrog](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91910852/d7dbfe5f-3cae-4feb-809f-fde95a191d81)
