### PR TITLE
belindas-closet-nextjs_6_351_update-product-sizing

### DIFF
--- a/app/add-product-page/product-prop-list.tsx
+++ b/app/add-product-page/product-prop-list.tsx
@@ -27,6 +27,6 @@ export enum ProductSizesList {
   XXL = "XXL",
 }
 
-export const ProductSizePantsWaistList = [28, 30, 32, 34, 36, 38, 40, 42];
+export const ProductSizePantsWaistList = [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42];
 
 export const ProductSizePantsInseamList = [28, 30, 32, 34, 36, 38, 40, 42];

--- a/app/add-product-page/product-prop-list.tsx
+++ b/app/add-product-page/product-prop-list.tsx
@@ -16,7 +16,7 @@ export enum ProductGenderList {
   NON_BINARY = "NON_BINARY",
 }
 
-export const ProductSizeShoeList = [5, 6, 7, 8, 9, 10, 11, 12];
+export const ProductSizeShoeList = [4, 4.5, 5, 5.5, 6, 6.5, 7, 7.5, 8, 8.5, 9, 9.5, 10, 10.5, 11, 11.5, 12, 12.5, 13];
 
 export enum ProductSizesList {
   XS = "XS",

--- a/app/add-product-page/product-prop-list.tsx
+++ b/app/add-product-page/product-prop-list.tsx
@@ -29,4 +29,4 @@ export enum ProductSizesList {
 
 export const ProductSizePantsWaistList = [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42];
 
-export const ProductSizePantsInseamList = [28, 30, 32, 34, 36, 38, 40, 42];
+export const ProductSizePantsInseamList = [28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42];


### PR DESCRIPTION
Resolves #351 

This PR adds sizes 4, 13, and half-sizes to the shoe sizes dropdown on the Add Product page. It also adds odd numbers for waist and inseam lengths between 28 and 42 for pants.

Shoe sizes:
<img width="400" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/b869a7c7-edad-4469-8f53-d423a2b9de1a">

Waist and inseam sizes:
<img width="400" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/3acc1c8b-c2c1-40b7-a4dc-b23b71a6122b">


Related to #350 