### PR TITLE
belinda-nextjs-6-353-add-auto-update-new-code

### DIFF
--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -1,0 +1,44 @@
+name: Continuous Deployment via SSH
+on:
+  [workflow_dispatch]
+  # push:
+  #  branches:
+  #   - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Install SSH Key
+        run: |
+          mkdir -p ~/.ssh/
+          echo "${{ secrets.DEPLOYUSERSSHKEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+
+      - name: Execute Deployment Commands
+        run: |
+          ssh -o StrictHostKeyChecking=no deployuser@44.238.195.106 << 'EOF'
+            source ~/.profile || true
+            source ~/.bashrc || true
+            # Ensure you're in the correct directory
+            cd ~/belindasFrontEnd
+            # Fetch the latest changes
+            git pull origin main
+            # Activate the Node.js version managed by nvm
+            source ~/.nvm/nvm.sh
+            nvm use ${{ matrix.node-version }}
+            # Install any new dependencies using npm from nvm
+            npm install
+            # Build the project
+            npm run build
+            # Restart the application with PM2
+            pm2 restart belindas-frontend
+          EOF


### PR DESCRIPTION
Resolves #353 
Related https://github.com/SeattleColleges/belindas-closet/issues/73

This PR will allow for merged code to be immediately deployed to our live website.

Following ssh.yml in the nsc-nestjs, I've changed a couple of things:
1. Added `node-version: [18.x, 20.x]` to allow system using various node version
2. Changed IP address from `deployuser@54.186.121.210` to `deployuser@44.238.195.106`
_Note: Not sure where the IP address **54.186.121.210** comes from, so I tested with **44.238.195.106** as our IP address and it works_ 

### As far as I know, the only way to test this PR:
#### 1. Go to my forked repo: https://github.com/tinpham5614/belindas-closet-nextjs
#### 2. Click the Action tab as the screenshot
![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/ec061c2c-e00d-4aeb-bcfc-81efd9668489)
#### 3. Select the Continuous Deployment as the screenshot
![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/fcabae88-43ae-433f-9fe1-0af57cfdff4e)
#### 4. Click "Run workflow" to trigger the event on the right screen as the screenshot.
![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/b811bbf9-5ca0-4152-bca4-7a4487247d0e)


**Successful pull and restart pm2**
_Note: Maybe we need the next PRs to see changes in the online web version._
![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/c5fb47d7-32d2-4743-b7d5-321752d4c428)

![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/0a2e1fad-b5dc-4f79-8935-b090ae5b4fe8)

![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/a41a3153-111f-43dd-9579-76711668cc41)

