### PR TITLE
belindas-closet-nextjs_6_365_edit-user-role-buttons-menu

### DIFF
--- a/components/EditUserRoleDialog.tsx
+++ b/components/EditUserRoleDialog.tsx
@@ -163,9 +163,11 @@ export function ConfirmationDialogRaw(
  */
 export default function EditUserRoleDialog({
   user,
+  onRoleChange,
 }: {
   user: UserCardProps;
   onClose: () => void;
+  onRoleChange: (newRole: string) => void;
 }): JSX.Element {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState(user.role);
@@ -183,6 +185,7 @@ export default function EditUserRoleDialog({
 
     if (newValue) {
       setValue(newValue);
+      onRoleChange(newValue);
     }
   };
 

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -13,13 +13,21 @@ export interface UserCardProps {
 
 function UserCard({ user }: { user: UserCardProps }) {
   const [openDialog, setOpenDialog] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const handleEditClick = () => {
-    setOpenDialog(true);
+    if (menuOpen) {
+      setMenuOpen(false);
+      setOpenDialog(false);
+    } else {
+      setOpenDialog(true);
+      setMenuOpen(true)
+    }
   };
 
   const handleCloseDialog = () => {
     setOpenDialog(false);
+    setMenuOpen(false);
   };
   return (
     <Container
@@ -65,7 +73,7 @@ function UserCard({ user }: { user: UserCardProps }) {
             startIcon={<EditIcon />}
             onClick={handleEditClick}
           >
-            Edit
+            {menuOpen ? "Done" : "Edit"}
           </Button>
         </Box>
       </Stack>

--- a/components/UserCard.tsx
+++ b/components/UserCard.tsx
@@ -14,15 +14,23 @@ export interface UserCardProps {
 function UserCard({ user }: { user: UserCardProps }) {
   const [openDialog, setOpenDialog] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [currentRole, setCurrentRole] = useState(user.role);
 
   const handleEditClick = () => {
     if (menuOpen) {
       setMenuOpen(false);
       setOpenDialog(false);
+      if (currentRole !== user.role) {
+        window.location.reload();
+      }
     } else {
       setOpenDialog(true);
       setMenuOpen(true)
     }
+  };
+
+  const handleRoleChange = (newRole: string) => {
+    setCurrentRole(newRole);
   };
 
   const handleCloseDialog = () => {
@@ -63,7 +71,7 @@ function UserCard({ user }: { user: UserCardProps }) {
         </Typography>
         {openDialog && (
           <Box display="flex" justifyContent="center">
-            <EditUserRoleDialog user={user} onClose={handleCloseDialog} />
+            <EditUserRoleDialog user={user} onClose={handleCloseDialog} onRoleChange={handleRoleChange} />
           </Box>
         )}
         <Box p={2} display="flex" justifyContent="center">


### PR DESCRIPTION
Resolves #365 

This PR makes it so that pressing the "Edit" button changes it to "Done" and pressing "Done" closes the menu. The page reloads to reflect these changes when the user role is successfully updated and presses "Done".

https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/0b3b662d-d804-419e-97aa-e21c67aae540

Related to #364 