### PR TITLE
belinda-nextjs-6-384-update-cd-with-nvmrc-02

### DIFF
--- a/.github/workflows/ssh.yml
+++ b/.github/workflows/ssh.yml
@@ -47,6 +47,7 @@ jobs:
             npm install
             # Build the project
             npm run build
-            # Restart the application with PM2
+            # Install and restart the application with PM2
+            npm install pm2 -g
             pm2 restart belindas-frontend
           EOF


### PR DESCRIPTION
This PR will add pm2 installation globally for the selected Node version.

**Error occurs:**
**_pm2 not found due to missing pm2 in the new node_** 
![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/f5e02160-b7bb-4665-a4f5-f940d2d0a648)

**Successful**

_**the new node version (stored in nvmrc file) is installed and used by nvm**_
![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/a8df7475-10cd-4642-ab91-4c0a8250df5e)


**_pm2 restarted after install pm2 using new node version_**
![image](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/72054441/4af06720-0960-448d-a4ec-9d3dcf4d9997)
