### PR TITLE
belindas-closet-nextjs-8-442-sign-up-page-unit-test-bug-repair

### DIFF
--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -250,7 +250,7 @@ const SignUp = () => {
           <Box textAlign="center" sx={{ mt: 2 }}>
             <Typography variant="body2">
               Already have an account?{" "}
-              <MuiLink href="/auth/sign-up" variant="body2">
+              <MuiLink href="/auth/sign-in" variant="body2">
                 {"Sign In"}
               </MuiLink>
             </Typography>

--- a/tests/unit/auth/sign-up/page.test.tsx
+++ b/tests/unit/auth/sign-up/page.test.tsx
@@ -9,6 +9,7 @@ describe('Sign up page tests', () => {
   // Arrange
   beforeEach(() => {
     jest.clearAllMocks();
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle
     render(<SignUp />)
   })
   it('render contains title, submit button, and sign in link', () => {
@@ -28,7 +29,7 @@ describe('Sign up page tests', () => {
     }
   })
 
-  it('sign in link direct to localhost /auth/sign-up route', () => {
+  it('sign in link direct to localhost /auth/sign-in route', () => {
     // Arrange
     const signinLink = screen.getByRole('link', { name: /sign in/i })
 
@@ -36,6 +37,6 @@ describe('Sign up page tests', () => {
     fireEvent.click(signinLink)
 
     // Assert
-    expect(signinLink).toHaveProperty('href', 'http://localhost/auth/sign-up')
+    expect(signinLink).toHaveProperty('href', 'http://localhost/auth/sign-in')
   })
 })

--- a/tests/unit/auth/sign-up/page.test.tsx
+++ b/tests/unit/auth/sign-up/page.test.tsx
@@ -9,7 +9,6 @@ describe('Sign up page tests', () => {
   // Arrange
   beforeEach(() => {
     jest.clearAllMocks();
-    // eslint-disable-next-line testing-library/no-render-in-lifecycle
     render(<SignUp />)
   })
   it('render contains title, submit button, and sign in link', () => {


### PR DESCRIPTION
Resolves #442 
This PR repairs the sign-in link route on the sign-up page unit test. It also corrections the expected link route that comes from the sign-up page itself because the same bug was on that page which is why the test worked previously.

