### PR TITLE
belindas-closet-nextjs_8_448_simplify-product-description

### DIFF
--- a/app/category-page/[categoryId]/page.tsx
+++ b/app/category-page/[categoryId]/page.tsx
@@ -76,15 +76,15 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
       </Typography>
       <Grid container spacing={2}>
         {filteredProducts.map((product, index) => (
-          <Grid item key={index} xs={12} sm={6} md={4}>
+          <Grid item key={index} xs={12} sm={4} md={2.5}>
             <ProductCard
               image={logo}
               categories={product.productType}
               gender={product.productGender}
-              sizeShoe={product.productSizeShoe}
-              size={product.productSizes}
-              sizePantsWaist={product.productSizePantsWaist}
-              sizePantsInseam={product.productSizePantsInseam}
+              sizeShoe=''
+              size=''
+              sizePantsWaist=''
+              sizePantsInseam=''
               description={product.productDescription}
               href={`/category-page/${categoryId}/products/${product._id}`} // Construct the URL
               _id={product._id}


### PR DESCRIPTION
Resolves #448 #449

This PR minimizes product descriptions on the category page (to just the gender and item's description, and doesn't include sizes). The product cards are smaller now so there can be more columns.

Before
![Screenshot 2024-06-11 223608](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/d38bb3d9-9d84-41be-8012-6cf3e48ce8de)

After 
![Screenshot 2024-06-11 223643](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/61bd4e1e-df5d-4aa9-abc0-eecfc780abdb)
