### PR TITLE
belindas-closet-nextjs_8_remove-unrelated-fields_product-detail-page

### DIFF
--- a/app/category-page/[categoryId]/page.tsx
+++ b/app/category-page/[categoryId]/page.tsx
@@ -76,15 +76,15 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
       </Typography>
       <Grid container spacing={2}>
         {filteredProducts.map((product, index) => (
-          <Grid item key={index} xs={12} sm={6} md={4}>
+          <Grid item key={index} xs={12} sm={4} md={2.5}>
             <ProductCard
               image={logo}
               categories={product.productType}
               gender={product.productGender}
-              sizeShoe={product.productSizeShoe}
-              size={product.productSizes}
-              sizePantsWaist={product.productSizePantsWaist}
-              sizePantsInseam={product.productSizePantsInseam}
+              sizeShoe=''
+              size=''
+              sizePantsWaist=''
+              sizePantsInseam=''
               description={product.productDescription}
               href={`/category-page/${categoryId}/products/${product._id}`} // Construct the URL
               _id={product._id}

--- a/app/category-page/[categoryId]/products/[productId]/ProductDetailDisplay.tsx
+++ b/app/category-page/[categoryId]/products/[productId]/ProductDetailDisplay.tsx
@@ -66,7 +66,7 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
     setOpenEditDialog(false);
   };
 
-  // Check if the product is a shoe
+  // Check if the product is a shoe, pants, etc. 
   const isShoeProduct = product.productType.includes("Shoes");
   const isPantsProduct = product.productType.includes("Pants");
 
@@ -99,9 +99,10 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
                     Product Shoe Size: {product.productSizeShoe || "N/A"}
                   </Typography>
                 )}
-                <Typography variant="h6">
+                {!isShoeProduct && (<Typography variant="h6">
                   Product Size: {product.productSizes || "N/A"}
                 </Typography>
+                )}
                 {!isShoeProduct && isPantsProduct && (
                   <>
                     <Typography variant="h6">

--- a/app/category-page/[categoryId]/products/[productId]/ProductDetailDisplay.tsx
+++ b/app/category-page/[categoryId]/products/[productId]/ProductDetailDisplay.tsx
@@ -1,13 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import logo from "@/public/belinda-images/logo.png";
-import {
-  Box,
-  Button,
-  Paper,
-  Stack,
-  Typography,
-} from "@mui/material";
+import { Box, Button, Paper, Stack, Typography } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import EditIcon from "@mui/icons-material/Edit";
 import ArchiveIcon from "@mui/icons-material/Archive";
@@ -72,6 +66,10 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
     setOpenEditDialog(false);
   };
 
+  // Check if the product is a shoe
+  const isShoeProduct = product.productType.includes("Shoes");
+  const isPantsProduct = product.productType.includes("Pants");
+
   return (
     <Stack>
       <Typography component="h1" variant="h4">
@@ -96,20 +94,24 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
                 <Typography variant="h6">
                   Product Gender: {product.productGender}
                 </Typography>
-                <Typography variant="h6">
-                  Product Shoe Size: {product.productSizeShoe || "N/A"}
-                </Typography>
+                {isShoeProduct && (
+                  <Typography variant="h6">
+                    Product Shoe Size: {product.productSizeShoe || "N/A"}
+                  </Typography>
+                )}
                 <Typography variant="h6">
                   Product Size: {product.productSizes || "N/A"}
                 </Typography>
-                <Typography variant="h6">
-                  Product Size Pants Waist:{" "}
-                  {product.productSizePantsWaist || "N/A"}
-                </Typography>
-                <Typography variant="h6">
-                  Product Size Pants Inseam:{" "}
-                  {product.productSizePantsInseam || "N/A"}
-                </Typography>
+                {!isShoeProduct && isPantsProduct && (
+                  <>
+                    <Typography variant="h6">
+                      Product Size Pants Waist: {product.productSizePantsWaist || "N/A"}
+                    </Typography>
+                    <Typography variant="h6">
+                      Product Size Pants Inseam: {product.productSizePantsInseam || "N/A"}
+                    </Typography>
+                  </>
+                )}
                 <Typography variant="h6">
                   Product Description: {product.productDescription || "N/A"}
                 </Typography>
@@ -128,61 +130,62 @@ const ProductDetailDisplay = ({ product }: { product: Product | null }) => {
         </Box>
 
         {userRole === "admin" || userRole === "creator" ? (
-        <Stack direction="row" spacing={2} justifyContent="center">
-          {/* Edit Button */}
-          <Box p={2} display="flex" justifyContent="center">
-            <Button
-              variant="contained"
-              color="primary"
-              startIcon={<EditIcon />}
-              onClick={handleEditButtonClick}
-            >
-              Edit
-            </Button>
-          </Box>
-          {/* Delete Button */}
-          <Box p={2} display="flex" justifyContent="center">
-            <Button
-              variant="contained"
-              color="error"
-              startIcon={<DeleteIcon />}
-              onClick={handleDeleteButtonClick}
-            >
-              Delete
-            </Button>
-          </Box>
-          {/* Archive Button */}
-          <Box p={2} display="flex" justifyContent="center">
-            <Button
-              variant="contained"
-              color="warning"
-              startIcon={<ArchiveIcon />}
-              onClick={handleArchiveButtonClick}
-            >
-              Archive
-            </Button>
-          </Box>
-        </Stack>
-          ) : null}
+          <Stack direction="row" spacing={2} justifyContent="center">
+            {/* Edit Button */}
+            <Box p={2} display="flex" justifyContent="center">
+              <Button
+                variant="contained"
+                color="primary"
+                startIcon={<EditIcon />}
+                onClick={handleEditButtonClick}
+              >
+                Edit
+              </Button>
+            </Box>
+            {/* Delete Button */}
+            <Box p={2} display="flex" justifyContent="center">
+              <Button
+                variant="contained"
+                color="error"
+                startIcon={<DeleteIcon />}
+                onClick={handleDeleteButtonClick}
+              >
+                Delete
+              </Button>
+            </Box>
+            {/* Archive Button */}
+            <Box p={2} display="flex" justifyContent="center">
+              <Button
+                variant="contained"
+                color="warning"
+                startIcon={<ArchiveIcon />}
+                onClick={handleArchiveButtonClick}
+              >
+                Archive
+              </Button>
+            </Box>
+          </Stack>
+        ) : null}
 
-          <EditProductDialog
-            open={openEditDialog}
-            onClose={handleCloseEditDialog}
-            product={product}
-          />
-          <ConfirmDeleteDialog
-            open={openDeleteDialog}
-            onClose={handleCloseDeleteDialog}
-            product={product}
-          />
-          <ConfirmArchiveDialog
-            open={openArchiveDialog}
-            onClose={handleCloseArchiveDialog}
-            product={product}
-          />
+        <EditProductDialog
+          open={openEditDialog}
+          onClose={handleCloseEditDialog}
+          product={product}
+        />
+        <ConfirmDeleteDialog
+          open={openDeleteDialog}
+          onClose={handleCloseDeleteDialog}
+          product={product}
+        />
+        <ConfirmArchiveDialog
+          open={openArchiveDialog}
+          onClose={handleCloseArchiveDialog}
+          product={product}
+        />
       </Paper>
     </Stack>
   );
 };
 
 export default ProductDetailDisplay;
+


### PR DESCRIPTION
Resolves #462, #464 
Related #454 

note: this is from sprint 7 but I'm doing this for sprint 8 (that's why two labels are on this)

This PR is for updating the product detail page by displaying correct fields for certain products, removing unrelated ones from displaying.

Pants waist and inseam only appear on pants products:
![pants](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91708459/6cdd809d-5445-4675-833f-f8e96b63de7b)

Shoes only display shoe size:
![shoes](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91708459/dd60c86d-366d-4fd8-aa4c-2522a93ddb2f)

Shirts and other products display size and description
![shirts](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91708459/b3bc4d46-0042-4b29-bb9e-67781ce7e1ef)
![accessories](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91708459/7a550ea9-a590-4e62-b2bc-4c4c06e60826)

This is all I could find for incorrect fields
Let me know if this is correct or if changes are needed, I can make them

future suggestion issue: maybe adding more distinct fields for certain items

Update: Shoes only display shoe size, removed size field (Ignore previous image of shoes)
![shoes2](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/91708459/9f1c9dea-876e-4e47-b3ae-ba36b26b0262)
  