### PR TITLE
belindas-closet-nextjs_8_444_display-archived-products

### DIFF
--- a/app/archived-products-page/page.tsx
+++ b/app/archived-products-page/page.tsx
@@ -74,7 +74,7 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
       </Typography>
       <Grid container spacing={2}>
         {filteredProducts.map((product, index) => (
-          <Grid item key={index} xs={12} sm={4} md={2.5}>
+          <Grid item key={index} xs={12} sm={4} md={3}>
             <ProductCard
               image={logo}
               categories={product.productType}

--- a/app/archived-products-page/page.tsx
+++ b/app/archived-products-page/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+import { Typography, Drawer, List, ListItem, ListItemText, IconButton } from "@mui/material";
+import { SetStateAction, useState } from "react";
+import MenuIcon from '@mui/icons-material/Menu';
+
+const ArchivedProducts = () => {
+    return (
+        <Typography component="h1" variant="h3">
+          Archived Products
+        </Typography>
+      );
+    };
+
+export default ArchivedProducts;

--- a/app/archived-products-page/page.tsx
+++ b/app/archived-products-page/page.tsx
@@ -1,14 +1,106 @@
 "use client";
-import { Typography, Drawer, List, ListItem, ListItemText, IconButton } from "@mui/material";
-import { SetStateAction, useState } from "react";
-import MenuIcon from '@mui/icons-material/Menu';
 
-const ArchivedProducts = () => {
-    return (
-        <Typography component="h1" variant="h3">
-          Archived Products
-        </Typography>
-      );
-    };
+import React, { useState, useEffect, Dispatch, SetStateAction } from "react";
+import ProductCard from "@/components/ProductCard";
+import logo from "@/public/belinda-images/logo.png";
+import { Container, Grid, Typography } from "@mui/material";
+// WARNING: You won't be able to connect to local backend unless you remove the env variable below.
+const URL = process.env.BELINDAS_CLOSET_PUBLIC_API_URL || "http://localhost:3000/api";
+const placeholderImg = logo;
+interface Product {
+  _id: string;
+  productImage: typeof placeholderImg;
+  productType: string[];
+  productGender: string;
+  productSizeShoe: string;
+  productSizes: string;
+  productSizePantsWaist: string;
+  productSizePantsInseam: string;
+  productDescription: string;
+  isHidden: Boolean;
+  isSold: Boolean;
+}
 
-export default ArchivedProducts;
+async function fetchData(
+  categoryId: string,
+  setProducts: Dispatch<SetStateAction<Product[]>>
+) {
+  const apiUrl = `${URL}/products`;
+  const fetchUrl = `${apiUrl}`;
+
+  try {
+    const res = await fetch(fetchUrl, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    if (!res.ok) {
+      throw new Error(res.statusText);
+    } else {
+      const data = await res.json();
+      const filteredData = data.filter((product: Product) => product.isSold);
+      setProducts(data);
+      console.log(data);
+    }
+  } catch (error) {
+    console.error("Error getting product:", error);
+  }
+}
+
+const ViewProduct = ({ categoryId }: { categoryId: string }) => {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [filteredProducts, setFilteredProducts] = useState<Product[]>([]);
+
+  useEffect(() => {
+    fetchData(categoryId, setProducts); // Pass categoryId to fetchData
+  }, [categoryId]);
+
+  useEffect(() => {
+    setFilteredProducts(
+      products.filter((product) => !product.isHidden && product.isSold)
+    );
+  }, [products]);
+
+  return (
+    <Container sx={{ py: 4 }} maxWidth="lg">
+      <Typography
+        variant="h4"
+        gutterBottom
+        justifyContent={"center"}
+        align={"center"}
+      >
+        Found {filteredProducts.length} products in Archived Products
+      </Typography>
+      <Grid container spacing={2}>
+        {filteredProducts.map((product, index) => (
+          <Grid item key={index} xs={12} sm={4} md={2.5}>
+            <ProductCard
+              image={logo}
+              categories={product.productType}
+              gender={product.productGender}
+              sizeShoe=''
+              size=''
+              sizePantsWaist=''
+              sizePantsInseam=''
+              description={product.productDescription}
+              href={`/category-page/${categoryId}/products/${product._id}`} // Construct the URL
+              _id={product._id}
+              isHidden={false}
+              isSold={false}
+            />
+          </Grid>
+        ))}
+      </Grid>
+    </Container>
+  );
+};
+export default function ProductList({
+  params,
+}: {
+  params: { categoryId: string };
+}) {
+  const decodedCategoryId = decodeURIComponent(params.categoryId);
+
+  return <ViewProduct categoryId={decodedCategoryId} />;
+}


### PR DESCRIPTION
Resolves #444 

This PR creates an Archived Products page, accessed at /archived-products-page, and displays products that have been archived. I tweaked the product card information to minimize it (similarly to the category-page) and adjusted the sizes to allow for more items on the page.
I placed the page in the main "app" directory rather than in category-page, not sure if I was supposed to do that!

Four columns with minimized info for each product (consistent with category-page's appearance in #468):
![Screenshot 2024-06-26 220211](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/8607225f-7630-4046-8e64-b5276820d037)

