### PR TITLE
belindas-closet-nextjs_9_469_add-all-products-link-to-nav-bar

### DIFF
--- a/components/CategoryDropDownMenu.tsx
+++ b/components/CategoryDropDownMenu.tsx
@@ -3,6 +3,7 @@ import { Container, Button, Menu, MenuItem } from "@mui/material";
 import { ArrowDropDown } from "@mui/icons-material";
 import { useRouter } from "next/navigation";
 const navItems = [
+  "All Products",
   "Shirts",
   "Shoes",
   "Pants",
@@ -25,8 +26,12 @@ export default function CategoryDropDownMenu() {
   };
   const router = useRouter();
   const navigate = (item: string) => {
-    const encodedCategoryId = encodeURIComponent(item); //sanitize item name for route
-    router.push(`/category-page/${encodedCategoryId}`);
+    if (item === "All Products") {
+      router.push(`/category-page/all-products`);
+    } else {
+      const encodedCategoryId = encodeURIComponent(item); //sanitize item name for route
+      router.push(`/category-page/${encodedCategoryId}`);
+    }
     handleClose();
   };
 

--- a/components/CategoryDropDownMenu.tsx
+++ b/components/CategoryDropDownMenu.tsx
@@ -38,7 +38,7 @@ export default function CategoryDropDownMenu() {
         aria-haspopup="true"
         aria-expanded={open ? "true" : undefined}
         onClick={handleClick}
-        startIcon={<ArrowDropDown />}
+        endIcon={<ArrowDropDown />}
         color={open ? "inherit" : "inherit"}
       >
         Products


### PR DESCRIPTION
Resolves #469 

This PR adds an "All Products" link to the product dropdown on the nav bar, which when clicked, navigates the user to the All Products page. I also moved the arrow icon to the right of the product dropdown. 

<img width="510" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/539997b7-663e-4131-91b2-49cf6e307145">
