### PR TITLE
belindas-closet-nextjs_9_478_signup-signin-responsive-pages-responsiv…

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -12,6 +12,8 @@ import {
   Button,
   Typography,
   Link as MuiLink,
+  useTheme,
+  useMediaQuery,
 } from "@mui/material";
 // WARNING: You won't be able to connect to local backend unless you remove the env variable below.
 const URL =
@@ -64,18 +66,28 @@ const Signin = () => {
     window.location.reload();
   };
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+
   return (
     <Stack spacing={{ xs: "-6px", sm: "-6px" }} alignItems="center">
       <Image
         src={mascot}
         alt="logo"
-        style={{ width: 200, height: 100, zIndex: 0 }}
+        style={{ 
+          width: isMobile ? 150 : isTablet ? 160 : 200, 
+          height: isMobile ? 75 : isTablet ? 80 : 100, 
+          zIndex: 0,
+          marginTop: 15, 
+          marginBottom: isMobile ? 2 : isTablet ? 1 : 0.5
+        }}
       />
       <Paper
         elevation={4}
         sx={{
           padding: "20px",
-          width: "400px",
+          width: isMobile ? "280px ": "400px",
           display: "flex",
           flexDirection: "column",
           alignItems: "center",

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -3,7 +3,7 @@
 import { ChangeEventHandler, FormEventHandler, useState } from "react";
 import Visibility from "@mui/icons-material/Visibility";
 import VisibilityOff from "@mui/icons-material/VisibilityOff";
-import { IconButton, InputAdornment, TextField } from "@mui/material";
+import { IconButton, InputAdornment, TextField, useMediaQuery, useTheme } from "@mui/material";
 import { Box, Button, Paper, Typography, Stack } from "@mui/material";
 import Image from "next/image";
 import mascot from "@/public/belinda-images/nsc_mascot_green_cropped.png";
@@ -110,18 +110,28 @@ const SignUp = () => {
     }
   };
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'md'));
+
   return (
     <Stack spacing={{ xs: "-6px", sm: "-6px" }} alignItems="center">
       <Image
         src={mascot}
         alt="logo"
-        style={{ width: 200, height: 100, zIndex: 0 }}
+        style={{ 
+          width: isMobile ? 150 : isTablet ? 160 : 200, 
+          height: isMobile ? 75 : isTablet ? 80 : 100, 
+          zIndex: 0, 
+          marginTop: 15, 
+          marginBottom: isMobile ? 1.5 : 1 
+        }}
       />
       <Paper
         elevation={4}
         sx={{
           padding: "20px",
-          width: "400px",
+          width: isMobile ? "280px ": "400px",
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
@@ -137,7 +147,7 @@ const SignUp = () => {
           sx={{ mt: 1, width: "100%" }}
         >
           <TextField
-            sx={{ mb: 2 }}
+            sx={{ mb: isMobile ? 1 : 2 }}
             margin="normal"
             required
             fullWidth
@@ -150,7 +160,7 @@ const SignUp = () => {
             onChange={handleChange}
           />
           <TextField
-            sx={{ mb: 2 }}
+            sx={{ mb: isMobile ? 1 : 2 }}
             margin="normal"
             required
             fullWidth
@@ -163,7 +173,7 @@ const SignUp = () => {
             autoFocus={false}
           />
                <TextField
-            sx={{ mb: 2 }}
+            sx={{ mb: isMobile ? 1 : 2 }}
             margin="normal"
             required
             fullWidth
@@ -176,7 +186,7 @@ const SignUp = () => {
             autoFocus={false}
           />
           <TextField
-            sx={{ mb: 2 }}
+            sx={{ mb: isMobile ? 1 : 2 }}
             margin="normal"
             required
             fullWidth
@@ -190,7 +200,7 @@ const SignUp = () => {
             autoFocus={false}
           />
           <TextField
-            sx={{ mb: 2 }}
+            sx={{ mb: isMobile ? 1 : 2 }}
             margin="normal"
             required
             fullWidth
@@ -213,7 +223,7 @@ const SignUp = () => {
             }}
           />
           <TextField
-            sx={{ mb: 2 }}
+            sx={{ mb: isMobile ? 1 : 2 }}
             margin="normal"
             required
             fullWidth
@@ -243,7 +253,7 @@ const SignUp = () => {
             type="submit"
             fullWidth
             variant="contained"
-            sx={{ mt: 3, mb: 2 }}
+            sx={{ mt: isMobile ? 2: 3, mb: isMobile ? 1: 2 }}
           >
             Sign Up
           </Button>

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -172,7 +172,7 @@ const SignUp = () => {
             onChange={handleChange}
             autoFocus={false}
           />
-               <TextField
+          <TextField
             sx={{ mb: isMobile ? 1 : 2 }}
             margin="normal"
             required


### PR DESCRIPTION
Resolves #478

This PR ensures that the Sign Up and Sign In page has responsive UI and adjusts to mobile screen sizes (and tablet screens) well, with no cutoffs or the need to scroll horizontally. I made additional UI changes to make sure the frog mascot is resting on top of the Sign Up/Sign In box as closely as possible.

Test this PR by right clicking the page and using Inspect elements to enter the Toggle Device Toolbar and adjust the screen sizes.

Smallest mobile screen size:
![Screenshot 2024-07-07 231653](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/675e128d-8785-46a5-9880-00a46aa1b2f3)
![Screenshot 2024-07-07 231742](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/4ba1cee4-3a8c-4a4e-bd4e-045cb216b50a)
