### PR TITLE
belindas-closet-nextjs_9_477_refactor-nav-bar

### DIFF
--- a/components/AuthProfileMenu.tsx
+++ b/components/AuthProfileMenu.tsx
@@ -104,18 +104,6 @@ export default function AuthProfileMenu() {
           <Avatar /> My Account
         </MenuItem>
         <Divider />
-        <MenuItem onClick={handleClose}>
-          <ListItemIcon>
-            <PersonAdd fontSize="small" />
-          </ListItemIcon>
-          Add another account
-        </MenuItem>
-        <MenuItem onClick={handleClose}>
-          <ListItemIcon>
-            <Settings fontSize="small" />
-          </ListItemIcon>
-          Settings
-        </MenuItem>
         <MenuItem onClick={handleLogOut}>
           <ListItemIcon>
             <Logout fontSize="small" />

--- a/components/CategoryDropDownMenu.tsx
+++ b/components/CategoryDropDownMenu.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Container, Button, Menu, MenuItem, Box } from "@mui/material";
+import { Container, Button, Menu, MenuItem, Box, useTheme, useMediaQuery } from "@mui/material";
 import { ArrowDropDown } from "@mui/icons-material";
 import { useRouter } from "next/navigation";
 const navItems = [
@@ -16,6 +16,8 @@ const navItems = [
 ];
 
 export default function CategoryDropDownMenu() {
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -45,7 +47,7 @@ export default function CategoryDropDownMenu() {
         onClick={handleClick}
         endIcon={<ArrowDropDown />}
         color={open ? "inherit" : "inherit"}
-        sx={{ mr: 2 }}
+        sx={{ mr: isMobile ? 0 : 2 }}
       >
         Products
       </Button>

--- a/components/CategoryDropDownMenu.tsx
+++ b/components/CategoryDropDownMenu.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Container, Button, Menu, MenuItem } from "@mui/material";
+import { Container, Button, Menu, MenuItem, Box } from "@mui/material";
 import { ArrowDropDown } from "@mui/icons-material";
 import { useRouter } from "next/navigation";
 const navItems = [
@@ -36,7 +36,7 @@ export default function CategoryDropDownMenu() {
   };
 
   return (
-    <Container>
+    <Box>
       <Button
         id="basic-button"
         aria-controls={open ? "basic-menu" : undefined}
@@ -45,6 +45,7 @@ export default function CategoryDropDownMenu() {
         onClick={handleClick}
         endIcon={<ArrowDropDown />}
         color={open ? "inherit" : "inherit"}
+        sx={{ mr: 2 }}
       >
         Products
       </Button>
@@ -63,6 +64,6 @@ export default function CategoryDropDownMenu() {
           </MenuItem>
         ))}
       </Menu>
-    </Container>
+    </Box>
   );
 }

--- a/components/CategoryDropDownMenu.tsx
+++ b/components/CategoryDropDownMenu.tsx
@@ -59,6 +59,7 @@ export default function CategoryDropDownMenu() {
         MenuListProps={{
           "aria-labelledby": "basic-button",
         }}
+        sx={{ transform: 'translateX(-6px)' }}
       >
         {navItems.map((item) => (
           <MenuItem key={item} onClick={() => navigate(item)}>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -25,8 +25,8 @@ import ThemeToggle from "./ThemeToggle";
 
 const drawerWidth = 240;
 
-const navItems = ["Home", "Sign In", "Donation", "Mission", "Contact"];
-const links = ["/", "/auth/sign-in", "/donation-info", "/mission-page", "/contact-page"];
+const navItems = ["Home", "Donation", "Mission", "Contact"];
+const links = ["/", "/donation-info", "/mission-page", "/contact-page"];
 
 export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -142,6 +142,15 @@ export default function Navbar() {
                   </Link>
                 </Grid>
               )}
+              {!token ? (
+                <Grid item>
+                <Link href="/auth/sign-in" passHref>
+                  <Button sx={{ color: "primary.contrastText" }}>
+                    Sign In
+                  </Button>
+                </Link>
+              </Grid>
+              ) : null }
             </Grid>
           </Box>
           

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -125,7 +125,7 @@ export default function Navbar() {
             <Grid container spacing={2}>
               {navItems.map((item, index) => (
                 <Grid item key={item} sx={{ display: "flex" }}>
-                  {index === 2 ? <CategoryDropDownMenu /> : null}
+                  {index === 1 ? <CategoryDropDownMenu /> : null}
                     <Link href={links[index]} passHref>
                     <Button key={item} sx={{ color: "#fff" }}>
                         {item}
@@ -160,7 +160,8 @@ export default function Navbar() {
               display: "flex",
               justifyContent: "center",
               alignItems: "center",
-              ml: { xs: 0, sm: 2 },
+              ml: 2.5,
+              mr: 1
             }}
           >
             <ThemeToggle />

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -65,7 +65,7 @@ export default function Navbar() {
               color: "primary.main",
             }}
           >
-            {index === 2 ? <CategoryDropDownMenu /> : null}
+            {index === 1 ? <CategoryDropDownMenu /> : null}
             <Link href={links[index]} passHref>
               <Button key={item} onClick={handleDrawerToggle}>
                 {item}


### PR DESCRIPTION
Resolves #477 

This PR conditionally renders the "Sign In" link from nav bar only when user is not signed in. I also cleaned up the nav bar by evening out the spacing between the nav bar items and removing the "Add another account" and "Settings" options in the profile dropdown. 

Signed in:
<img width="500" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/cb706f70-9733-4efc-afbe-b67dd6c2802e">

Not signed in:
<img width="500" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/54c3687a-9573-4d62-a9e6-c41a4d2be654">


