### PR TITLE
belindas-closet-nextjs_9_485_forgot-change-pw-responsive-ui

### DIFF
--- a/app/auth/change-password-page/page.tsx
+++ b/app/auth/change-password-page/page.tsx
@@ -14,6 +14,8 @@ import {
   Paper,
   TextField,
   Typography,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import ErrorAlert from "@/components/ErrorAlert";
 import SuccessAlert from "@/components/SuccessAlert";
@@ -135,8 +137,11 @@ const ChangePasswordPage = () => {
     <CircularProgress />;
   }
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  
   return (
-    <Paper elevation={6} sx={{ width: "100%", maxWidth: 400, padding: 3 }}>
+    <Paper elevation={6} sx={{ width: isMobile ? "280px" : "400px", maxWidth: 400, padding: 3, mt: 3 }}>
       <Container
         disableGutters
         fixed
@@ -150,7 +155,7 @@ const ChangePasswordPage = () => {
         <Image
           src={logo}
           alt="logo"
-          style={{ width: 50, height: 50, marginBottom: 10 }}
+          style={{ width: 65, height: 50, marginBottom: 15 }}
         />
       </Container>
       <Typography component="h1" variant="h5" textAlign="center" sx={{ mb: 2 }}>
@@ -158,7 +163,7 @@ const ChangePasswordPage = () => {
       </Typography>
       <Box component="form" onSubmit={handleSubmit} noValidate sx={{ mt: 1 }}>
         <TextField
-          sx={{ mb: 2 }}
+          sx={{ mb: isMobile ? 1: 2 }}
           variant="outlined"
           margin="normal"
           required={true}
@@ -183,7 +188,7 @@ const ChangePasswordPage = () => {
           }}
         />
         <TextField
-          sx={{ mb: 2 }}
+          sx={{ mb: isMobile ? 1: 2 }}
           variant="outlined"
           margin="normal"
           required={true}
@@ -208,7 +213,7 @@ const ChangePasswordPage = () => {
           }}
         />
         <TextField
-          sx={{ mb: 2 }}
+          sx={{ mb: isMobile ? 1: 2 }}
           variant="outlined"
           margin="normal"
           required={true}

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { ChangeEventHandler, FormEventHandler, useState } from "react";
-import { Typography, Button, Box, TextField, Paper } from '@mui/material';
+import { Typography, Button, Box, TextField, Paper, useTheme, useMediaQuery } from '@mui/material';
 
 const ForgotPassword = () => {
   
@@ -23,15 +23,19 @@ const ForgotPassword = () => {
   // TODO: send email to user with reset password link
   };
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+
   return (
     <Paper
       elevation={4}
       sx={{
         padding: "20px",
-        width: "400px",
+        width: isMobile ? "280px ": "400px",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
+        mt: 3
       }}
     >
 


### PR DESCRIPTION
Resolves #485

This PR cleans up the UI for mobile screens for the Forgot Password and Change Password Pages and overall appearance in desktop screens as well to keep them consistent with other pages on the app.

Test this PR by right clicking the page and using Inspect elements to enter the Toggle Device Toolbar and adjust the screen sizes.

Smallest mobile screen size:
![Screenshot 2024-07-08 174712](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/1b4d7b8d-4259-466d-9429-655d67382983)
![Screenshot 2024-07-08 174724](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/8dfc79db-b09e-4a03-a29d-8b50c82f0064)