### PR TITLE
belindas-closet-nextjs_9_488_category-page-all-products-archived-prod…

### DIFF
--- a/app/archived-products-page/page.tsx
+++ b/app/archived-products-page/page.tsx
@@ -69,6 +69,7 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
         gutterBottom
         justifyContent={"center"}
         align={"center"}
+        mb={3}
       >
         Found {filteredProducts.length} products in Archived Products
       </Typography>

--- a/app/category-page/[categoryId]/page.tsx
+++ b/app/category-page/[categoryId]/page.tsx
@@ -71,6 +71,7 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
         gutterBottom
         justifyContent={"center"}
         align={"center"}
+        mb={3}
       >
         Found {filteredProducts.length} products in {categoryId}
       </Typography>

--- a/app/category-page/all-products/page.tsx
+++ b/app/category-page/all-products/page.tsx
@@ -69,6 +69,7 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
         gutterBottom
         justifyContent={"center"}
         align={"center"}
+        mb={3}
       >
         Found {filteredProducts.length} products in All Products
       </Typography>

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -4,7 +4,7 @@ import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import ButtonBase from "@mui/material/ButtonBase";
 import { StaticImageData } from "next/image";
-import { Stack, Button, Link } from "@mui/material";
+import { Stack, Button, Link, useTheme, useMediaQuery } from "@mui/material";
 import Image from "next/image";
 import DeleteIcon from "@mui/icons-material/Delete";
 import ArchiveIcon from "@mui/icons-material/Archive";
@@ -89,6 +89,10 @@ export default function ProductCard({
     window.location.reload();
   };
 
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isTablet = useMediaQuery(theme.breakpoints.between('sm', 'lg'));
+
   return (
     <Paper
       sx={{
@@ -105,11 +109,11 @@ export default function ProductCard({
         <Grid item>
           <ButtonBase>
             <Link href={href}>
-              <Image src={image} alt="product image" width={128} />
+              <Image src={image} alt="product image" width={isTablet ? 120 : 128} />
             </Link>
           </ButtonBase>
         </Grid>
-        <Grid item xs={12} sm container>
+        <Grid item xs={12} sm container justifyContent={isMobile ? "center" : isTablet ? "center" : "left"}>
           <Grid item xs container direction="column" spacing={2}>
             <Grid item xs>
               <Typography gutterBottom variant="subtitle1" component="div">
@@ -153,7 +157,7 @@ export default function ProductCard({
         </Button>
         {/* Only show delete and archive buttons if user is admin or creator */}
         {userRole === "admin" || userRole === "creator" ? (
-          <Stack direction="row" spacing={2}>
+          <Stack direction="row" spacing={2} justifyContent={"center"}>
             <Button
               variant="contained"
               startIcon={<DeleteIcon />}


### PR DESCRIPTION
Resolves #488

This PR ensures that certain elements, such as the "Edit" and "Archive" buttons, and product detail text are properly centered on mobile/tablet screens.

I also tweaked margin spaces and sizes of certain elements outside of mobile screen sizes, so that the space was distributed better (image being large was causing the product detail text to be cut off and pushed to the side), so my changes improved it a bit.

Smallest mobile screen size (example using Category-page):
![Screenshot 2024-07-08 231435](https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77607212/780d9863-73b7-4732-99e7-2c3033912e8f)
