### PR TITLE
belindas-closet-nextjs_9_490_fix-color-of-links-and-focused-text-fields

### DIFF
--- a/app/theme/themes.tsx
+++ b/app/theme/themes.tsx
@@ -43,10 +43,24 @@ let darkTheme = createTheme({
     },
     MuiOutlinedInput: {
       styleOverrides: {
+        root: {
+          "&.Mui-focused .MuiOutlinedInput-notchedOutline": {
+            borderColor: "#fff",
+          },
+        },
         input: {
           '&:-webkit-autofill': {
-            '-webkit-box-shadow': '0 0 0 100px #E8F0FE inset',
-            '-webkit-text-fill-color': '#000',
+            '-webkit-box-shadow': '0 0 0 100px rgba(69, 69, 69) inset',
+            '-webkit-text-fill-color': '#fff',
+          },
+        },
+      },
+    },
+    MuiInputLabel: {
+      styleOverrides: {
+        root: {
+          '&.Mui-focused': {
+            color: '#fff'
           },
         },
       },

--- a/app/theme/themes.tsx
+++ b/app/theme/themes.tsx
@@ -32,7 +32,25 @@ let darkTheme = createTheme({
           backgroundColor: "#333",
         },
       },
-    }
+    },
+    MuiLink: {
+      styleOverrides: {
+        root: {
+          color: "#fff",
+          textDecorationColor: "#fff"
+        },
+      },
+    },
+    MuiOutlinedInput: {
+      styleOverrides: {
+        input: {
+          '&:-webkit-autofill': {
+            '-webkit-box-shadow': '0 0 0 100px #E8F0FE inset',
+            '-webkit-text-fill-color': '#000',
+          },
+        },
+      },
+    },
   },
 });
 darkTheme = responsiveFontSizes(darkTheme);


### PR DESCRIPTION
Resolves #490 

This PR fixes the low contrast color of links and focused text fields on the Sign up, Sign in, Forgot Password, Change password, & Add Product pages in dark mode, to make these elements more readable for the user.

Before with autofill:
<img width="300" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/3be237c9-1206-4f25-af79-d018a91bf2d2">
Before without autofill:
<img width="300" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/c4ff1ebe-51ca-406f-8623-5dc3cc5b72b2">


After:
<img width="300" alt="image" src="https://github.com/SeattleColleges/belindas-closet-nextjs/assets/77591083/12f5d398-d680-447e-8dc9-0344b5f9b270">
