### PR TITLE
 Bug Fix: fetch logic to display users

### DIFF
--- a/app/edit-user-role-page/page.tsx
+++ b/app/edit-user-role-page/page.tsx
@@ -16,17 +16,24 @@ interface User {
   email: string;
   role: string;
 }
+type JWToken = string | null
 /**
  * fetch user info from the server
  * @param setUserInfo
+ * JWT token for user authentication
+ * @param userToken
  */
-async function fetchUser(setUserInfo: (userInfo: User[]) => void) {
+async function fetchUser(setUserInfo: (userInfo: User[]) => void, userToken: JWToken) {
   const apiUrl = `${URL}/user`;
   try {
+    if (!userToken) {
+      throw new Error('JWT token not found in storage')
+    }
     const res = await fetch(apiUrl, {
       method: "GET",
       headers: {
         "Content-Type": "application/json",
+        "Authorization": `Bearer ${userToken}`,
       },
     });
     if (!res.ok) {
@@ -34,7 +41,6 @@ async function fetchUser(setUserInfo: (userInfo: User[]) => void) {
     } else {
       const data = await res.json();
       setUserInfo(data);
-      console.log(data);
     }
   } catch (error) {
     console.error("Error getting user info:", error);
@@ -49,7 +55,8 @@ const EditUserRolePage = () => {
   const [userInfo, setUserInfo] = useState<User[]>([]);
 
   useEffect(() => {
-    fetchUser(setUserInfo);
+    const userToken:JWToken = localStorage.getItem("token")
+    fetchUser(setUserInfo,userToken);
   }, []);
 
   return (

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   distDir: "build",
+  //reactStrictMode: false, // Uncomment to test API behavior using front-end
   env: {
     // variable call would be process.env.BELINDAS_CLOSET_PUBLIC_API_URL,
     BELINDAS_CLOSET_PUBLIC_API_URL: "https://belindascloset.com/api",


### PR DESCRIPTION
Resolves #471  

This PR updates the user fetch logic with the user's JW token.  In our backend, we updated our [get all users endpoint](https://github.com/SeattleColleges/belindas-closet-nestjs/blob/main/src/user/controllers/user/user.controller.ts#L20) to require the admin role in the user's JW Token. This restriction prevented the edit user role page from fetching all users from database. 

The commit includes the ability to disable strict mode in the next.config.js file. Using useEffect to trigger a fetch call in [strict mode causes the fetch request to fire twice](https://www.upgradejs.com/blog/javascript/react/updates-to-strict-mode-in-react-18.html). After further investigation, I found that strict mode is enabled by default in next.js. I included it as a quick way to disable strict mode when testing API endpoints using the front-end. 

How to test
- run front-end and back-end, login using a user with admin privileges, click My Account under the user icon, then click Edit user 

Note: [Double check the back-end listener is set to 3000 ](https://github.com/SeattleColleges/belindas-closet-nestjs/blob/main/src/main.ts#L25)since[ front-end expects the backend port to be set at 3000](https://github.com/SeattleColleges/belindas-closet-nextjs/blob/main/app/auth/sign-in/page.tsx#L20). 

Results:
![CleanShot 2024-07-16 at 21 02 14@2x](https://github.com/user-attachments/assets/01360d0e-08ff-428b-abfa-4a8fca1c2a23)
