### PR TITLE
belindas-closet-nextjs_10_506_fix-redirects-when-signing-in-out

### DIFF
--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -15,6 +15,7 @@ import {
   useTheme,
   useMediaQuery,
 } from "@mui/material";
+import useAuth from "@/hooks/useAuth";
 // WARNING: You won't be able to connect to local backend unless you remove the env variable below.
 const URL =
   process.env.BELINDAS_CLOSET_PUBLIC_API_URL || "http://localhost:3000/api";
@@ -27,6 +28,7 @@ const Signin = () => {
   });
 
   const router = useRouter();
+  const { user, isAuth } = useAuth();
 
   const { email, password } = userInfo;
 
@@ -54,6 +56,7 @@ const Signin = () => {
       const { token } = await res.json();
       localStorage.setItem("token", token);
       const userRole = JSON.parse(atob(token.split(".")[1])).role; // decode token to get user role
+      window.dispatchEvent(new CustomEvent('auth-change'));
       // Redirect to user page
       if (userRole === "admin") {
         router.push("/admin-page"); // redirect to admin-page which is not created yet
@@ -63,7 +66,6 @@ const Signin = () => {
         router.push("/profile"); // TODO: change profile to user-page
       }
     }
-    window.location.reload();
   };
 
   const theme = useTheme();

--- a/components/AuthProfileMenu.tsx
+++ b/components/AuthProfileMenu.tsx
@@ -1,4 +1,5 @@
 "use client";
+import useAuth from "@/hooks/useAuth";
 import { PersonAdd, Settings, Logout } from "@mui/icons-material";
 import {
   Avatar,
@@ -15,14 +16,8 @@ import React, { Fragment } from "react";
 
 export default function AuthProfileMenu() {
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
-  const [userRole, setUserRole] = React.useState("");
+  const { user, isAuth } = useAuth();
   const token = localStorage.getItem("token");
-  React.useEffect(() => {
-    if (token) {
-      const role = JSON.parse(atob(token.split(".")[1])).role;
-      setUserRole(role);
-    }
-  }, [token, userRole]);
   
   const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
@@ -35,9 +30,9 @@ export default function AuthProfileMenu() {
   const router = useRouter();
 
   const handleMyAccount = () => {
-    if (userRole == "admin") {
+    if (user?.role == "admin") {
       router.push("/admin-page")
-    } else if (userRole == "creator") {
+    } else if (user?.role == "creator") {
       router.push("/creator-page")
     } else {
       router.push("/profile")
@@ -46,71 +41,74 @@ export default function AuthProfileMenu() {
 
   const handleLogOut = () => {
     localStorage.removeItem("token");
-    window.location.reload();
+    window.dispatchEvent(new CustomEvent('auth-change'));
     router.push("/");
   };
-  return (
-    <Fragment>
-      <Box sx={{ display: "flex", alignItems: "center", textAlign: "center" }}>
-        <Tooltip title="Account settings">
-          <IconButton
-            onClick={handleClick}
-            size="small"
-            sx={{ ml: 2 }}
-            aria-controls={open ? "account-menu" : undefined}
-            aria-haspopup="true"
-            aria-expanded={open ? "true" : undefined}
-          >
-            <Avatar sx={{ width: 32, height: 32 }}></Avatar>
-          </IconButton>
-        </Tooltip>
-      </Box>
-      <Menu
-        anchorEl={anchorEl}
-        id="account-menu"
-        open={open}
-        onClose={handleClose}
-        onClick={handleClose}
-        PaperProps={{
-          elevation: 0,
-          sx: {
-            overflow: "visible",
-            filter: "drop-shadow(0px 2px 8px rgba(0,0,0,0.32))",
-            mt: 1.5,
-            "& .MuiAvatar-root": {
-              width: 32,
-              height: 32,
-              ml: -0.5,
-              mr: 1,
+
+  if (isAuth) {
+    return (
+      <Fragment>
+        <Box sx={{ display: "flex", alignItems: "center", textAlign: "center" }}>
+          <Tooltip title="Account settings">
+            <IconButton
+              onClick={handleClick}
+              size="small"
+              sx={{ ml: 2 }}
+              aria-controls={open ? "account-menu" : undefined}
+              aria-haspopup="true"
+              aria-expanded={open ? "true" : undefined}
+            >
+              <Avatar sx={{ width: 32, height: 32 }}></Avatar>
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <Menu
+          anchorEl={anchorEl}
+          id="account-menu"
+          open={open}
+          onClose={handleClose}
+          onClick={handleClose}
+          PaperProps={{
+            elevation: 0,
+            sx: {
+              overflow: "visible",
+              filter: "drop-shadow(0px 2px 8px rgba(0,0,0,0.32))",
+              mt: 1.5,
+              "& .MuiAvatar-root": {
+                width: 32,
+                height: 32,
+                ml: -0.5,
+                mr: 1,
+              },
+              "&::before": {
+                content: '""',
+                display: "block",
+                position: "absolute",
+                top: 0,
+                right: 14,
+                width: 10,
+                height: 10,
+                bgcolor: "background.paper",
+                transform: "translateY(-50%) rotate(45deg)",
+                zIndex: 0,
+              },
             },
-            "&::before": {
-              content: '""',
-              display: "block",
-              position: "absolute",
-              top: 0,
-              right: 14,
-              width: 10,
-              height: 10,
-              bgcolor: "background.paper",
-              transform: "translateY(-50%) rotate(45deg)",
-              zIndex: 0,
-            },
-          },
-        }}
-        transformOrigin={{ horizontal: "right", vertical: "top" }}
-        anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
-      >
-        <MenuItem onClick={handleMyAccount}>
-          <Avatar /> My Account
-        </MenuItem>
-        <Divider />
-        <MenuItem onClick={handleLogOut}>
-          <ListItemIcon>
-            <Logout fontSize="small" />
-          </ListItemIcon>
-          Logout
-        </MenuItem>
-      </Menu>
-    </Fragment>
-  );
+          }}
+          transformOrigin={{ horizontal: "right", vertical: "top" }}
+          anchorOrigin={{ horizontal: "right", vertical: "bottom" }}
+        >
+          <MenuItem onClick={handleMyAccount}>
+            <Avatar /> My Account
+          </MenuItem>
+          <Divider />
+          <MenuItem onClick={handleLogOut}>
+            <ListItemIcon>
+              <Logout fontSize="small" />
+            </ListItemIcon>
+            Logout
+          </MenuItem>
+        </Menu>
+      </Fragment>
+    );
+  };
 }

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -22,6 +22,7 @@ import MenuIcon from "@mui/icons-material/Menu";
 import CategoryDropDownMenu from "./CategoryDropDownMenu";
 import AuthProfileMenu from "./AuthProfileMenu";
 import ThemeToggle from "./ThemeToggle";
+import useAuth from "@/hooks/useAuth";
 
 const drawerWidth = 240;
 
@@ -30,23 +31,13 @@ const links = ["/", "/donation-info", "/mission-page", "/contact-page"];
 
 export default function Navbar() {
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [userRole, setUserRole] = useState("");
+  const { isAuth, user } = useAuth();
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
   const handleDrawerToggle = () => {
     setMobileOpen((prevState) => !prevState);
   };
-
-  const [token, setToken] = useState("");
-  useEffect(() => {
-    const token = localStorage.getItem("token");
-    if (token) {
-      setToken(token);
-      const userRole = JSON.parse(atob(token.split(".")[1])).role;
-      setUserRole(userRole);
-    }
-  }, []);
 
   const drawer = (
     <Box sx={{ textAlign: "center" }}>
@@ -73,7 +64,7 @@ export default function Navbar() {
             </Link>
           </Grid>
         ))}
-        {(userRole === "admin" || userRole === "creator") && (
+        {isAuth && user && (user.role === "admin" || user.role === "creator") && (
           <Grid item>
             <Link href="/dashboard" passHref>
               <Button onClick={handleDrawerToggle}>
@@ -82,7 +73,7 @@ export default function Navbar() {
             </Link>
           </Grid>
         )}
-        {!token ? (
+        {!isAuth ? (
           <Grid item>
           <Link href="/auth/sign-in" passHref>
             <Button>
@@ -104,7 +95,7 @@ export default function Navbar() {
           justifyContent: "center",
         }}
       >
-        {token ? <AuthProfileMenu /> : null}
+        {isAuth ? <AuthProfileMenu /> : null}
       </Grid>
     </Box>
   );
@@ -142,7 +133,7 @@ export default function Navbar() {
                     </Link>
                 </Grid>
               ))}
-              {(userRole === "admin" || userRole === "creator") && (
+              {isAuth && user && (user.role === "admin" || user.role === "creator") && (
                 <Grid item>
                   <Link href="/dashboard" passHref>
                     <Button sx={{ color: "primary.contrastText" }}>
@@ -151,7 +142,7 @@ export default function Navbar() {
                   </Link>
                 </Grid>
               )}
-              {!token ? (
+              {!isAuth ? (
                 <Grid item>
                 <Link href="/auth/sign-in" passHref>
                   <Button sx={{ color: "primary.contrastText" }}>
@@ -159,7 +150,7 @@ export default function Navbar() {
                   </Button>
                 </Link>
               </Grid>
-              ) : null }
+              ) : null}
             </Grid>
           </Box>
           
@@ -176,7 +167,7 @@ export default function Navbar() {
             <ThemeToggle />
           </Box>
           <Grid item sx={{ display: "flex", justifyContent: "center" }}>
-            {token ? <AuthProfileMenu /> : null}
+            {isAuth ? <AuthProfileMenu /> : null}
           </Grid>
         </Toolbar>
       </AppBar>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -82,6 +82,15 @@ export default function Navbar() {
             </Link>
           </Grid>
         )}
+        {!token ? (
+          <Grid item>
+          <Link href="/auth/sign-in" passHref>
+            <Button>
+              Sign In
+            </Button>
+          </Link>
+        </Grid>
+        ) : null }
       </List>
       <Divider />
 

--- a/hooks/useAuth.tsx
+++ b/hooks/useAuth.tsx
@@ -1,0 +1,43 @@
+{/* Custom React hook to manage and track user authentication state.*/}
+import { useState, useEffect } from 'react';
+
+interface User {
+  role: string; 
+}
+
+const useAuth = () => {
+  const [isAuth, setIsAuth] = useState(false);
+  const [user, setUser] = useState<User | null>(null);
+
+  const checkAuth = () => {
+    const token = localStorage.getItem('token');
+    setIsAuth(!!token);
+    if (token) {
+      // Decode token, update user state
+      const user = JSON.parse(atob(token.split('.')[1]));
+      setUser(user);
+    } else {
+      setUser(null);
+    }
+  };
+
+  useEffect(() => {
+    checkAuth(); // Initial check
+
+    const handleAuthChange = () => {
+      checkAuth();
+    };
+    // Listen for 'auth-change' events to dynamically update auth state across the app.
+    window.addEventListener('auth-change', handleAuthChange);
+
+    // Cleanup by removing the event listener on component unmount.
+    return () => {
+      window.removeEventListener('auth-change', handleAuthChange);
+    };
+  }, []);
+
+  return { isAuth, user };
+};
+
+
+export default useAuth;


### PR DESCRIPTION
Resolves #506 

This PR fixes the issue of the user not being redirected when signing in or signing out. I added the useAuth hook from (from NSC Events), which helps track if the user is signed in or out and updates the nav bar automatically without having to refresh the page. Before adding the hook, I was having difficulty having the page redirect while also reflecting the changes in the nav bar when signing in or signing out.

I also added the Sign In link to the hamburger nav menu when the user is not signed in.

Signing in now redirects to the Admin/Creator for admins and creators, and the Profile page for users.
Signing out now redirects to the Home page.