### PR TITLE
belindas-closet-nextjs_10_522_fix-typos-heading-margin-space

### DIFF
--- a/app/add-product-page/page.tsx
+++ b/app/add-product-page/page.tsx
@@ -165,13 +165,13 @@ const AddProduct = () => {
           <Typography
             component="h1"
             variant="h3"
-            sx={{ marginBottom: "15px" }}
+            sx={{ mb: 3, mt: 3 }}
           >
             Add a Product
           </Typography>
 
           {/* Product Type Field */}
-          <FormControl variant="filled" sx={{ m: 1, minWidth: 120 }}>
+          <FormControl variant="filled" sx={{ m: 1, minWidth: 250 }}>
             <InputLabel id="type-selectlabel">Product Type</InputLabel>
             <Select
               labelId="type-selectlabel"
@@ -347,7 +347,7 @@ const AddProduct = () => {
               color="primary"
               onClick={handleSubmit}
               type="submit"
-              sx={{ mt: 1 }}
+              sx={{ m: 1, mt: 2 }}
             >
               Submit
             </Button>

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -178,7 +178,7 @@ const SignUp = () => {
             required
             fullWidth
             id="pronoun"
-            label="Pronoun"
+            label="Pronouns"
             name="pronoun"
             autoComplete="pronoun"
             value={pronoun}

--- a/app/contact-page/page.tsx
+++ b/app/contact-page/page.tsx
@@ -15,8 +15,8 @@ import { Typography, Box, TextField, Button } from "@mui/material";
 
 const Contact = () => {
   return (
-    <Box sx={{ padding: 4}}>
-      <Box sx={{ display: 'flex', justifyContent: 'center', mb: 4 }}>
+    <Box sx={{ padding: 3 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'center', mb: 4, mt: 3 }}>
         <Typography component="h1" variant="h3" gutterBottom>
           Contact Us
         </Typography>
@@ -42,7 +42,7 @@ const Contact = () => {
               fullWidth
             />
             <TextField
-              label="Buisness (optional)"
+              label="Business (optional)"
               variant="outlined"
               fullWidth
             />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -75,7 +75,7 @@ const Dashboard = () => {
         <Typography
           component="h1"
           variant="h3"
-          sx={{ color: "white", marginLeft: drawerOpen ? 240 : 0 }}
+          sx={{ color: "white", marginLeft: drawerOpen ? 240 : 0, mt: 3 }}
         >
           Dashboard
         </Typography>


### PR DESCRIPTION
Resolves #522

This PR cleans up pages by fixing typos on Contact and Sign Up pages, margin heading space on Dashboard and Add Product page along with buttons being the same width as the fields on the Add Product page and all fields being wider for smaller screens.

Improved Add Product page on mobile screen:

![Screenshot 2024-07-28 021453](https://github.com/user-attachments/assets/d6c428b8-a4b8-4c31-9521-1378ca857570)
