### PR TITLE
belindas-closet-nextjs-10-528-add-button-redirect-admin-profile-page

### DIFF
--- a/app/admin-page/page.tsx
+++ b/app/admin-page/page.tsx
@@ -78,6 +78,16 @@ const Admin = () => {
               Archived Products
             </Button>
           </Grid>
+          <Grid item xs={12} sm="auto">
+            <Button 
+              href="/profile" 
+              color="primary" 
+              variant="contained"
+              sx={{ width: "200px" }}
+            >
+              Profile
+            </Button>
+          </Grid>
         </Grid>
       </Box>
     </div>

--- a/tests/unit/admin-page/admin.test.tsx
+++ b/tests/unit/admin-page/admin.test.tsx
@@ -35,7 +35,8 @@ describe.each(roles)('admin-page tests for role: %s', (role) => {
 
             const links = screen.getAllByRole('link'); // Update to search for links
             const buttonText = screen.getByText('Edit User Roles');
-            expect(links && buttonText).toBeInTheDocument();
+            const profileBtn = screen.getByText('Profile');
+            expect(links && buttonText && profileBtn).toBeInTheDocument();
         });
     };
 });


### PR DESCRIPTION
Resolves #528 
Adds profile button in admin page which redirects user to their profile page when clicked.
![image](https://github.com/user-attachments/assets/5bd24863-fad7-4d0a-9b57-f808eb8cf71e)
