### PR TITLE
belindas_closet_nextjs_11_532_add-profile-button-to-creator-page

### DIFF
--- a/app/creator-page/page.tsx
+++ b/app/creator-page/page.tsx
@@ -37,7 +37,7 @@ const Creator = () => {
                 flexDirection="column"
                 sx={{ mt: 6 }}
             >
-                <Grid container spacing={ isMobile ? 3 : 2 } justifyContent="center" alignItems="center">
+                <Grid container spacing={isMobile ? 3 : 2} justifyContent="center" alignItems="center">
                     <Grid item xs={12} sm="auto">
                         <Button 
                             href="/add-product-page"
@@ -66,6 +66,16 @@ const Creator = () => {
                             sx={{ width: "200px" }}
                         >
                             Archived Products
+                        </Button>
+                    </Grid> 
+                    <Grid item xs={12} sm="auto">
+                        <Button
+                            href="/profile"
+                            color="primary"
+                            variant="contained"
+                            sx={{ width: "200px" }}
+                        >
+                            Profile
                         </Button>
                     </Grid>
                 </Grid>


### PR DESCRIPTION
Resolves #532 

This PR is for adding a profile button on the creator page that routes to the profile page when clicked on. 

this is the how the creator page looks like:
![creator-page-profile](https://github.com/user-attachments/assets/79e98521-1dbe-4813-bb56-30eaef019e72)

when the button is clicked its routed here: 
![profile-page](https://github.com/user-attachments/assets/0508e4a6-b109-4c42-ab2c-d49d98cb5734)

to test this: `npm install` then `npm run dev` and type /creator-page to view page, make sure you are logged in as a creator for access to page. if needed log in as admin and switch another account you have to creator. 