### PR TITLE
belindas-closet-nextjs_11_531_remove-archive-button-archived-products-page

### DIFF
--- a/app/archived-products-page/page.tsx
+++ b/app/archived-products-page/page.tsx
@@ -72,7 +72,7 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
     }
   }, []);
 
-  if ((userRole === "admin" || userRole === "creator")) {
+  if (userRole === "admin" || userRole === "creator") {
     return (
       <Container sx={{ py: 4 }} maxWidth="lg">
         <Typography
@@ -100,6 +100,7 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
                 _id={product._id}
                 isHidden={false}
                 isSold={false}
+                showArchiveButton={false} // Pass the prop to hide the archive button
               />
             </Grid>
           ))}
@@ -110,6 +111,7 @@ const ViewProduct = ({ categoryId }: { categoryId: string }) => {
     return <UnauthorizedPageMessage />;
   }
 };
+
 export default function ProductList({
   params,
 }: {

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -26,7 +26,7 @@ type ProductCardProps = {
   _id: string;
   isHidden: boolean;
   isSold: boolean;
-  showArchiveButton: boolean;
+  showArchiveButton?: boolean; // optional
 };
 export default function ProductCard({
   image,

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import Grid from "@mui/material/Grid";
 import Paper from "@mui/material/Paper";
@@ -24,6 +26,7 @@ type ProductCardProps = {
   _id: string;
   isHidden: boolean;
   isSold: boolean;
+  showArchiveButton: boolean;
 };
 export default function ProductCard({
   image,
@@ -36,6 +39,7 @@ export default function ProductCard({
   description,
   href,
   _id,
+  showArchiveButton,
 }: ProductCardProps) {
   const [userRole, setUserRole] = React.useState("");
 
@@ -166,7 +170,8 @@ export default function ProductCard({
             >
               Delete
             </Button>
-            <Button
+            {showArchiveButton && (
+              <Button
               variant="contained"
               startIcon={<ArchiveIcon />}
               color="warning"
@@ -174,7 +179,7 @@ export default function ProductCard({
               sx={{ fontSize: 10 }}
             >
               Archive
-            </Button>
+            </Button> )}
           </Stack>
         ) : null}
       </Stack>


### PR DESCRIPTION
Resolves #531 

This PR removes the archive button that shows up on the product card from the archived products page. 

before archive button removed:
![archived-products](https://github.com/user-attachments/assets/f75c9b7e-79eb-41ba-b56a-f7a2d7cc2473)

after archive button removed (this is what the page should look like): 
![archived-products-no-button](https://github.com/user-attachments/assets/9066a53d-35ac-46d0-9264-09f2050654df)

to test this: `npm install` then `npm run dev` and navigate to the archived products page to see the button removed.
