### PR TITLE
belindas-closet-nextjs_15_557_footer-bug-fix

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -60,11 +60,22 @@ export default function Navbar() {
           </Box>
           <Box sx={{ display: { xs: "none", md: "block" } }}>
             <Grid container spacing={1}>
-              <Grid item sx={{ display: "flex" }}>
+              <Grid item sx={{ 
+                display: "flex",
+                flexShrink: 0,
+                alignItems: "center",
+                marginRight: "1rem", 
+                }}
+                >
                 <CategoryDropDownMenu />
               </Grid>
               {isAuth && user && (user.role === "admin" || user.role === "creator") && (
-                <Grid item>
+                <Grid item sx={{
+                  flexShrink: 0,
+                  alignItems: "center",
+                  marginLeft: "1rem",
+                }}
+                >
                   <Link href="/dashboard" passHref>
                     <Button sx={{ color: "primary.contrastText" }}>
                       Dashboard

--- a/components/WrapperDiv.tsx
+++ b/components/WrapperDiv.tsx
@@ -1,21 +1,22 @@
 import React from "react";
 import { Box, BoxProps } from "@mui/material";
 
-const styles = {
-  borderRadius: "0.5rem",
-  width: "100%",
-  height: "100%",
-  display: "flex",
-  flexDirection: "column",
-  justifyContent: "center",
-  alignItems: "center",
-  gap: "1rem",
-  textAlign: "center",
-  paddingBottom: 5
-};
-
-const CustomCardContent: React.FC<BoxProps> = ({ children }) => {
-  return <Box sx={styles}>{children}</Box>;
+const CustomCardContent: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <Box
+      sx={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "flex-start",
+        alignItems: "center",
+        width: "100%",
+        padding: "1rem",
+      }}
+    >
+      {children}
+    </Box>
+  );
 };
 
 export default CustomCardContent;


### PR DESCRIPTION
Resolves #557 

This PR fixes a bug associated with the Footer component for Belinda's Closet. The Footer component did not rest flush with the bottom of the page, which was initially tested with the user-type account. I additionally made creator and admin accounts to test with, finding that the issue was present with all account types.

The problem stemmed mostly from how WrapperDiv was treating spacing with its children, which the Footer was being considered. Making changes as to how the layout would effect the Footer, while also removing a redundant call on Footer, I was able to secure the component in its proper spot at the bottom of the page.

The NavBar work was performed due to the WrapperDiv changing positioning of the Products and Dashboard links in the Navbar. 

The work performed can be summarized, as such:

WrapperDiv:

- Refactored WrapperDiv to manage its layout more effectively, ensuring it works seamlessly with the Footer component
- Removed redundant Footer inclusion inside WrapperDiv to avoid duplication and conflicts

NavBar fixes:

- Resolved an overlap between the Products dropdown menu and the Dashboard link for admin and creator users
- Adjusted spacing and alignment using Grid and Box properties to ensure consistent separation of NavBar items

**Admin - Edit User Role Page**
![Admin - Edit User Role Page](https://github.com/user-attachments/assets/e6456031-6c1c-4b34-b3e0-950b158fe389)

**Creator - Add Product Page**
![Creator - Add Product Page](https://github.com/user-attachments/assets/5c9f9ea7-f259-4254-b7a1-2fc69128243f)

**User - Profile Page**
![User](https://github.com/user-attachments/assets/ba99ae70-2b7c-412b-acdd-cf95cf26ca5b)
