### PR TITLE
belindas-closet-nextjs_15_565_contact-us-page-dependency-update

### DIFF
--- a/app/contact-page/page.tsx
+++ b/app/contact-page/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { Typography, Box, TextField, Button } from "@mui/material";
-import emailjs from 'emailjs-com';
+import emailjs from '@emailjs/browser';
 
 
 const Contact = () => {
@@ -53,7 +53,7 @@ const Contact = () => {
         }
 
     //send the email if validation is successful
-    emailjs.sendForm('service_tcqmiub', 'template_umbo1q7', e.target as HTMLFormElement, 'iHLRPRzpKKnhc1Mlr')
+    emailjs.sendForm('service_xinlmmj', 'template_umbo1q7', e.target as HTMLFormElement, 'iHLRPRzpKKnhc1Mlr')
       .then((result) => {
         alert('Message sent successfully!');
         setFormData({

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "autoprefixer": "10.4.20",
         "bcrypt": "5.1.1",
         "chart.js": "4.4.4",
-        "emailjs-com": "3.2.0",
         "eslint": "8.50.0",
         "eslint-config-next": "14.2.14",
         "mongoose": "8.7.0",
@@ -4531,13 +4530,6 @@
     "node_modules/electron-to-chromium": {
       "version": "1.5.32",
       "license": "ISC"
-    },
-    "node_modules/emailjs-com": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-      "node": "20.x"
+    "node": "20.x"
   },
   "scripts": {
     "dev": "next dev -p 8082",
@@ -30,7 +30,6 @@
     "@types/react-dom": "18.3.0",
     "autoprefixer": "10.4.20",
     "bcrypt": "5.1.1",
-    "emailjs-com": "3.2.0",
     "chart.js": "4.4.4",
     "eslint": "8.50.0",
     "eslint-config-next": "14.2.14",


### PR DESCRIPTION
Resolves #565 

This PR updates the contact-us page to use the correct dependency for email forwarding

![image](https://github.com/user-attachments/assets/5844a91c-b29b-4933-a4d9-adab7a762faf)

To test:

1. run belindas-closet nextjs app locally
2. navigate to contact-us page and fill out the form then press send
3. Log in to emailjs dashboard using belindasclosettest@gmail.com and password Testing123!
4. Navigate to email history and confirm that email has been sent