### PR TITLE
belindas-closet-nextjs-sprint17-fix-empty-carousel-placement-on-homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -158,8 +158,9 @@ const Home = () => {
           </Grid>
         </Grid>
 
-      <Carousel carouselID="womenswear" 
+     <Carousel carouselID="womenswear" 
       title="Recent Womenswear"
+      
       products={products.filter((product: Product) => (product.productGender.includes('FEMALE') || product.productGender.includes('NON-BINARY')))}/>
 
       <Carousel carouselID="menswear" 
@@ -167,6 +168,7 @@ const Home = () => {
       products={products.filter((product: Product) => (product.productGender.includes('MALE') || product.productGender.includes('NON-BINARY')))}/>
     </WrapperDiv>
   );
+  
 };
 
 export default Home;

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -114,7 +114,7 @@ const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(
             }, 25);
         }
 
-        return (
+        return products.length > 0?(
             <CarouselComponentWrapper>
                 <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
                 <CarouselContainerWrapper>
@@ -131,6 +131,15 @@ const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(
                             <MdArrowBackIos  aria-label="Toggle Light Theme"/>
                         </IconContext.Provider>
                     </CarouselArrowRight>
+                </CarouselContainerWrapper>
+            </CarouselComponentWrapper>
+        ):(
+            <CarouselComponentWrapper>
+                <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
+                <CarouselContainerWrapper>
+                    <CarouselContainer id={carouselID}>
+                    {children}
+                    </CarouselContainer>
                 </CarouselContainerWrapper>
             </CarouselComponentWrapper>
         );


### PR DESCRIPTION
This is an update on the Carousel placement issue on the homepage. So the main issue itself, is that the Carousel elements are appearing on the homepage when there is no data in the database. 
![411363188-ccee3501-bb55-46db-91db-5d14e54d22c3](https://github.com/user-attachments/assets/a2d802a9-1f36-41ef-9bf8-de27d644f0d3)

So what I have done is modified the return statement in the Carousel.tsx file. I have it set to only display the Carousel arrows (CarouselArrowLeft and CarouselArrowRight) if the products.length is greater than zero. If not, then it will still have the CarouselComponentWrapper, but will not display the arrows. 
![Screenshot-1-Update-1](https://github.com/user-attachments/assets/12f8b9f6-514c-4c34-b50e-801517ea506b)'

Here we can see that the Carousel arrow elements are not appearing on the homepage because there is no data in the database.
![Screenshot-2-Update-1](https://github.com/user-attachments/assets/f7854a2f-9c73-4264-b1fb-e1618c29d7ae)

So is one possible solution. However this only works in theory at the moment, because I don't have any data to populate the database with. So I cannot tell if the Carousel arrows and elements will work as needed when there **is data in the database**. 
So I need a way to populate the database with data to further test this out and see if this is the best solution for the bug.

Video Link:
https://screenrec.com/share/d1Npuw9JSk