### PR TITLE
belindas-closet-nextjs_sprint21_issue637_bugfix-homepage--make-components-match-the-width-of-the-window

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,7 +79,9 @@ const Home = () => {
         display: 'flex', 
         flexDirection: 'column', 
         alignItems: 'center',
-        width: '100%'
+        width: '100%',
+        maxWidth: '100vw',
+        overflowx: 'auto'
       }}>
         <ImageBanner />
         

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,8 +80,6 @@ const Home = () => {
         flexDirection: 'column', 
         alignItems: 'center',
         width: '100%',
-        //maxWidth: '100vw',
-        //overflowx: 'auto'
       }}>
         <ImageBanner />
         

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -80,8 +80,8 @@ const Home = () => {
         flexDirection: 'column', 
         alignItems: 'center',
         width: '100%',
-        maxWidth: '100vw',
-        overflowx: 'auto'
+        //maxWidth: '100vw',
+        //overflowx: 'auto'
       }}>
         <ImageBanner />
         

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -79,7 +79,7 @@ const Home = () => {
         display: 'flex', 
         flexDirection: 'column', 
         alignItems: 'center',
-        width: '100%',
+        width: '100%'
       }}>
         <ImageBanner />
         

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -16,12 +16,19 @@ export interface CarouselProps {
 
 type CarouselElementClassKey = "left" | "right";
 
+const ResponsiveWrapper = styled('div')(() => ({
+    width: '100%',
+    maxWidth: 1200,
+    margin: '0 auto',
+    position: 'relative',
+}));
+
 const CarouselComponentWrapper = styled('div', {
     name: 'CarouselElement',
     slot: 'overallWrapper',
 })(({ theme }) => ({
     height: 'fit-content',
-    width: '100%', // full width
+    width: '100%',
     position: 'relative',
     display: 'flex',
     alignItems: 'flex-start',
@@ -34,7 +41,7 @@ const CarouselContainerWrapper = styled('div', {
     slot: 'wrapper',
 })(({ theme }) => ({
     height: 'fit-content',
-    width: '100%', // full width
+    width: '100%',
     position: 'relative',
 }));
 
@@ -46,7 +53,7 @@ const CarouselContainer = styled('div', {
     flexDirection: 'row',
     gap: 20,
     overflowX: 'auto',
-    maxWidth: '100%', // full width
+    maxWidth: '100%',
     scrollSnapType: 'x mandatory',
     paddingBottom: 8,
     '&::-webkit-scrollbar': {
@@ -73,7 +80,7 @@ const CarouselArrowLeft = styled('div', {
     paddingLeft: 20,
     backgroundColor: "transparent",
     boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
-    zIndex: 2, // Make sure arrows stay above content
+    zIndex: 2,
 }));
 
 const CarouselArrowRight = styled('div', {
@@ -93,54 +100,64 @@ const CarouselArrowRight = styled('div', {
     paddingLeft: 20,
     backgroundColor: "transparent",
     boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
-    zIndex: 2, // Make sure arrows stay above content
+    zIndex: 2,
 }));
+
 const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(
     function Stat(inProps, ref) {
         const props = useThemeProps({ props: inProps, name: 'CarouselElement' });
-        const {children, carouselID, products, title, ...other } = props;
-        function slide(interval: number){
+        const { children, carouselID, products, title, ...other } = props;
+
+        function slide(interval: number) {
             var container = document.getElementById(carouselID);
             let scrollCompleted = 0;
-            var slideVar = setInterval(function(){
-            container!.scrollLeft += interval;
+            var slideVar = setInterval(function () {
+                container!.scrollLeft += interval;
                 scrollCompleted += 10;
-                if(scrollCompleted >= 100){
+                if (scrollCompleted >= 100) {
                     window.clearInterval(slideVar);
                 }
             }, 25);
         }
 
-return products.length > 0?(
-    <CarouselComponentWrapper>
-        <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
-        <CarouselContainerWrapper>
-            <CarouselArrowLeft onClick={()=>slide(-70)}>
-                <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
-                    <MdArrowBackIos  aria-label="Toggle Light Theme"/>
-                </IconContext.Provider>
-            </CarouselArrowLeft>
-            <CarouselContainer id={carouselID}>
-            {children}
-            </CarouselContainer>
-            <CarouselArrowRight onClick={()=>slide(70)}>
-                <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
-                    <MdArrowBackIos  aria-label="Toggle Light Theme"/>
-                </IconContext.Provider>
-            </CarouselArrowRight>
-        </CarouselContainerWrapper>
-    </CarouselComponentWrapper>
-):(
-    <CarouselComponentWrapper>
-        <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
-        <CarouselContainerWrapper>
-            <CarouselContainer id={carouselID}>
-                    {children}
-                </CarouselContainer>
-            </CarouselContainerWrapper>
-        </CarouselComponentWrapper>
-    );
-});
+        return products.length > 0 ? (
+            <ResponsiveWrapper>
+                <CarouselComponentWrapper>
+                    <Typography color="#114FA3" variant="h4" mt={2} sx={{ fontWeight: 900, textAlign: 'center' }}>
+                        {title}
+                    </Typography>
+                    <CarouselContainerWrapper>
+                        <CarouselArrowLeft onClick={() => slide(-70)}>
+                            <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
+                                <MdArrowBackIos aria-label="Toggle Light Theme" />
+                            </IconContext.Provider>
+                        </CarouselArrowLeft>
+                        <CarouselContainer id={carouselID}>
+                            {children}
+                        </CarouselContainer>
+                        <CarouselArrowRight onClick={() => slide(70)}>
+                            <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
+                                <MdArrowBackIos aria-label="Toggle Light Theme" />
+                            </IconContext.Provider>
+                        </CarouselArrowRight>
+                    </CarouselContainerWrapper>
+                </CarouselComponentWrapper>
+            </ResponsiveWrapper>
+        ) : (
+            <ResponsiveWrapper>
+                <CarouselComponentWrapper>
+                    <Typography color="#114FA3" variant="h4" mt={2} sx={{ fontWeight: 900, textAlign: 'center' }}>
+                        {title}
+                    </Typography>
+                    <CarouselContainerWrapper>
+                        <CarouselContainer id={carouselID}>
+                            {children}
+                        </CarouselContainer>
+                    </CarouselContainerWrapper>
+                </CarouselComponentWrapper>
+            </ResponsiveWrapper>
+        );
+    });
 
 declare module "@mui/material/styles" {
     interface Components {
@@ -170,12 +187,12 @@ const theme = createTheme({
 
 export function Carousel({ carouselID, products, title }: { carouselID: string; products: Product[]; title: string }) {
     return (
-        <Stack direction="row" spacing={2} sx={{ width: '100%' }}>
+        <Stack direction="row" spacing={2} sx={{ width: '100%', justifyContent: 'center' }}>
             <ThemeProvider theme={theme}>
                 <CarouselElement carouselID={carouselID} products={products} title={title}>
-                { products &&
-                        products.map((product, index)=>(
-                            <SimpleItemPreview product={product} key={index}/>
+                    {products &&
+                        products.map((product, index) => (
+                            <SimpleItemPreview product={product} key={index} />
                         ))
                     }
                 </CarouselElement>

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -36,7 +36,6 @@ const CarouselContainerWrapper = styled('div', {
     height: 'fit-content',
     width: '100%', // full width
     position: 'relative',
-    // NO overflow hidden here!
 }));
 
 const CarouselContainer = styled('div', {
@@ -96,11 +95,28 @@ const CarouselArrowRight = styled('div', {
     boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
     zIndex: 2, // Make sure arrows stay above content
 }));
-
+const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(
+    function Stat(inProps, ref) {
+        const props = useThemeProps({ props: inProps, name: 'CarouselElement' });
+        const {children, carouselID, products, title, ...other } = props;
+        function slide(interval: number){
+            var container = document.getElementById(carouselID);
+            let scrollCompleted = 0;
+            var slideVar = setInterval(function(){
+            container!.scrollLeft += interval;
+                scrollCompleted += 10;
+                if(scrollCompleted >= 100){
+                    window.clearInterval(slideVar);
+                }
+            }, 25);
+        }
+/*
 const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(function CarouselElement(inProps, ref) {
     const props = useThemeProps({ props: inProps, name: 'CarouselElement' });
     const { children, carouselID, products, title, ...other } = props;
+*/
 
+/*
     function slide(interval: number) {
         const container = document.getElementById(carouselID);
         if (!container) return;
@@ -113,28 +129,31 @@ const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(function
             }
         }, 25);
     }
-
-    return (
-        <CarouselComponentWrapper {...other}>
-            <Typography color="#114FA3" variant="h4" mt={2} sx={{ fontWeight: 900 }}>
-                {title}
-            </Typography>
-            <CarouselContainerWrapper>
-                {products.length > 0 && (
-                    <>
-                        <CarouselArrowLeft onClick={() => slide(-70)}>
-                            <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
-                                <MdArrowBackIos aria-label="Slide Left" />
-                            </IconContext.Provider>
-                        </CarouselArrowLeft>
-                        <CarouselArrowRight onClick={() => slide(70)}>
-                            <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
-                                <MdArrowBackIos aria-label="Slide Right" />
-                            </IconContext.Provider>
-                        </CarouselArrowRight>
-                    </>
-                )}
-                <CarouselContainer id={carouselID}>
+*/
+return products.length > 0?(
+    <CarouselComponentWrapper>
+        <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
+        <CarouselContainerWrapper>
+            <CarouselArrowLeft onClick={()=>slide(-70)}>
+                <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
+                    <MdArrowBackIos  aria-label="Toggle Light Theme"/>
+                </IconContext.Provider>
+            </CarouselArrowLeft>
+            <CarouselContainer id={carouselID}>
+            {children}
+            </CarouselContainer>
+            <CarouselArrowRight onClick={()=>slide(70)}>
+                <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
+                    <MdArrowBackIos  aria-label="Toggle Light Theme"/>
+                </IconContext.Provider>
+            </CarouselArrowRight>
+        </CarouselContainerWrapper>
+    </CarouselComponentWrapper>
+):(
+    <CarouselComponentWrapper>
+        <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
+        <CarouselContainerWrapper>
+            <CarouselContainer id={carouselID}>
                     {children}
                 </CarouselContainer>
             </CarouselContainerWrapper>

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -3,7 +3,7 @@ import { styled, useThemeProps, createTheme, ThemeProvider, Theme } from '@mui/m
 import * as React from 'react';
 import { OverridesStyleRules } from "@mui/material/styles/overrides";
 import { SimpleItemPreview } from './SimpleItemPreview';
-import { MdArrowBackIos  } from "react-icons/md";
+import { MdArrowBackIos } from "react-icons/md";
 import { IconContext } from "react-icons";
 import Product from '../models/productModel';
 
@@ -19,172 +19,165 @@ type CarouselElementClassKey = "left" | "right";
 const CarouselComponentWrapper = styled('div', {
     name: 'CarouselElement',
     slot: 'overallWrapper',
-    })(({ theme }) => ({
-        height: 'fit-content',
-        width: 'fit-content',
-        position: 'relative',
-        display: 'flex',
-        alignItems: 'flex-start',
-        flexDirection: 'column',
-        gap: 24
-    }));
+})(({ theme }) => ({
+    height: 'fit-content',
+    width: '100%', // full width
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'flex-start',
+    flexDirection: 'column',
+    gap: 24,
+}));
 
 const CarouselContainerWrapper = styled('div', {
     name: 'CarouselElement',
     slot: 'wrapper',
-    })(({ theme }) => ({
-        height: 'fit-content',
-        width: 'fit-content',
-        position: 'relative',
-    }));
+})(({ theme }) => ({
+    height: 'fit-content',
+    width: '100%', // full width
+    position: 'relative',
+    // NO overflow hidden here!
+}));
 
 const CarouselContainer = styled('div', {
     name: 'CarouselElement',
     slot: 'container',
-    })(({ theme }) => ({
-        display: 'flex',
-        flexDirection: 'row',
-        gap: 20,
-        overflowX: 'scroll',
-        maxWidth: 1200,
-        '&::-webkit-scrollbar': {
-            width: 0,
-            background: 'transparent',
-            height: 0
-          }
-    }));
+})(({ theme }) => ({
+    display: 'flex',
+    flexDirection: 'row',
+    gap: 20,
+    overflowX: 'auto',
+    maxWidth: '100%', // full width
+    scrollSnapType: 'x mandatory',
+    paddingBottom: 8,
+    '&::-webkit-scrollbar': {
+        width: 0,
+        background: 'transparent',
+        height: 0,
+    },
+}));
 
 const CarouselArrowLeft = styled('div', {
     name: 'CarouselElement',
     slot: 'leftarrow',
-    overridesResolver: (props, styles) => styles.left
-    })(({ theme }) => {
-        return {
-            position: 'absolute',
-            top: 55,
-            height: 70,
-            width: 70,
-            borderRadius: 40,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            cursor: 'pointer',
-            paddingLeft: 20,
-            backgroundColor: "transparent",
-            boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
-        }
-    }
-);
+    overridesResolver: (props, styles) => styles.left,
+})(({ theme }) => ({
+    position: 'absolute',
+    top: 55,
+    height: 70,
+    width: 70,
+    borderRadius: 40,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    paddingLeft: 20,
+    backgroundColor: "transparent",
+    boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
+    zIndex: 2, // Make sure arrows stay above content
+}));
 
 const CarouselArrowRight = styled('div', {
     name: 'CarouselElement',
     slot: 'rightarrow',
-    overridesResolver: (props, styles) => styles.right
-    })(({ theme }) => {
-        return {
-            position: 'absolute',
-            top: 55,
-            height: 70,
-            width: 70,
-            borderRadius: 40,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            cursor: 'pointer',
-            paddingLeft: 20,
-            backgroundColor: "transparent",
-            boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
-        }
+    overridesResolver: (props, styles) => styles.right,
+})(({ theme }) => ({
+    position: 'absolute',
+    top: 55,
+    height: 70,
+    width: 70,
+    borderRadius: 40,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    paddingLeft: 20,
+    backgroundColor: "transparent",
+    boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
+    zIndex: 2, // Make sure arrows stay above content
+}));
+
+const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(function CarouselElement(inProps, ref) {
+    const props = useThemeProps({ props: inProps, name: 'CarouselElement' });
+    const { children, carouselID, products, title, ...other } = props;
+
+    function slide(interval: number) {
+        const container = document.getElementById(carouselID);
+        if (!container) return;
+        let scrollCompleted = 0;
+        const slideInterval = setInterval(() => {
+            container.scrollLeft += interval;
+            scrollCompleted += 10;
+            if (scrollCompleted >= 100) {
+                clearInterval(slideInterval);
+            }
+        }, 25);
     }
-);
 
-const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(
-    function Stat(inProps, ref) {
-        const props = useThemeProps({ props: inProps, name: 'CarouselElement' });
-        const {children, carouselID, products, title, ...other } = props;
-        function slide(interval: number){
-            var container = document.getElementById(carouselID);
-            let scrollCompleted = 0;
-            var slideVar = setInterval(function(){
-            container!.scrollLeft += interval;
-                scrollCompleted += 10;
-                if(scrollCompleted >= 100){
-                    window.clearInterval(slideVar);
-                }
-            }, 25);
-        }
-
-        return products.length > 0?(
-            <CarouselComponentWrapper>
-                <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
-                <CarouselContainerWrapper>
-                    <CarouselArrowLeft onClick={()=>slide(-70)}>
-                        <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
-                            <MdArrowBackIos  aria-label="Toggle Light Theme"/>
-                        </IconContext.Provider>
-                    </CarouselArrowLeft>
-                    <CarouselContainer id={carouselID}>
+    return (
+        <CarouselComponentWrapper {...other}>
+            <Typography color="#114FA3" variant="h4" mt={2} sx={{ fontWeight: 900 }}>
+                {title}
+            </Typography>
+            <CarouselContainerWrapper>
+                {products.length > 0 && (
+                    <>
+                        <CarouselArrowLeft onClick={() => slide(-70)}>
+                            <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
+                                <MdArrowBackIos aria-label="Slide Left" />
+                            </IconContext.Provider>
+                        </CarouselArrowLeft>
+                        <CarouselArrowRight onClick={() => slide(70)}>
+                            <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
+                                <MdArrowBackIos aria-label="Slide Right" />
+                            </IconContext.Provider>
+                        </CarouselArrowRight>
+                    </>
+                )}
+                <CarouselContainer id={carouselID}>
                     {children}
-                    </CarouselContainer>
-                    <CarouselArrowRight onClick={()=>slide(70)}>
-                        <IconContext.Provider value={{ color: "#114FA3", size: '60' }}>
-                            <MdArrowBackIos  aria-label="Toggle Light Theme"/>
-                        </IconContext.Provider>
-                    </CarouselArrowRight>
-                </CarouselContainerWrapper>
-            </CarouselComponentWrapper>
-        ):(
-            <CarouselComponentWrapper>
-                <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
-                <CarouselContainerWrapper>
-                    <CarouselContainer id={carouselID}>
-                    {children}
-                    </CarouselContainer>
-                </CarouselContainerWrapper>
-            </CarouselComponentWrapper>
-        );
-},
-);
+                </CarouselContainer>
+            </CarouselContainerWrapper>
+        </CarouselComponentWrapper>
+    );
+});
 
 declare module "@mui/material/styles" {
     interface Components {
         CarouselElement?: {
-        styleOverrides?: Partial<
-          OverridesStyleRules<CarouselElementClassKey, "CarouselElement", Theme>
-        >;
-      };
+            styleOverrides?: Partial<
+                OverridesStyleRules<CarouselElementClassKey, "CarouselElement", Theme>
+            >;
+        };
     }
-  }
+}
 
 const theme = createTheme({
     components: {
         CarouselElement: {
-        styleOverrides: {
-          left: {
-            left: -40,
-          },
-          right: {
-            right: -40,
-            transform: "rotate(0.5turn)"
-          }
-        }
-      },
+            styleOverrides: {
+                left: {
+                    left: -40,
+                },
+                right: {
+                    right: -40,
+                    transform: "rotate(0.5turn)",
+                },
+            },
+        },
+    },
+});
 
-    }
-  });
-  
-export function Carousel({ carouselID, products, title }: { carouselID: string, products: Product[], title: string }){
+export function Carousel({ carouselID, products, title }: { carouselID: string; products: Product[]; title: string }) {
     return (
-        <Stack direction="row" spacing={2}>
-             <ThemeProvider theme={theme}>
+        <Stack direction="row" spacing={2} sx={{ width: '100%' }}>
+            <ThemeProvider theme={theme}>
                 <CarouselElement carouselID={carouselID} products={products} title={title}>
-                    { products &&
-                        products.map((product, index)=>(
-                            <SimpleItemPreview product={product} key={index}/>
-                        ))
-                    }
+                    {products.map((product, index) => (
+                        <SimpleItemPreview key={index} product={product} />
+                    ))}
                 </CarouselElement>
             </ThemeProvider>
         </Stack>
-    )
+    );
 }

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -81,7 +81,9 @@ const CarouselArrowLeft = styled('div', {
     backgroundColor: "transparent",
     boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
     zIndex: 2,
-}));
+        }
+    )
+);
 
 const CarouselArrowRight = styled('div', {
     name: 'CarouselElement',
@@ -101,7 +103,9 @@ const CarouselArrowRight = styled('div', {
     backgroundColor: "transparent",
     boxShadow: "inset 0 0 8px rgba(0, 0, 0, .75)",
     zIndex: 2,
-}));
+        }
+    )
+);
 
 const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(
     function Stat(inProps, ref) {
@@ -157,7 +161,8 @@ const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(
                 </CarouselComponentWrapper>
             </ResponsiveWrapper>
         );
-    });
+    },
+);
 
 declare module "@mui/material/styles" {
     interface Components {
@@ -185,13 +190,13 @@ const theme = createTheme({
     },
 });
 
-export function Carousel({ carouselID, products, title }: { carouselID: string; products: Product[]; title: string }) {
+export function Carousel({ carouselID, products, title }: { carouselID: string; products: Product[]; title: string }){
     return (
         <Stack direction="row" spacing={2} sx={{ width: '100%', justifyContent: 'center' }}>
             <ThemeProvider theme={theme}>
                 <CarouselElement carouselID={carouselID} products={products} title={title}>
-                    {products &&
-                        products.map((product, index) => (
+                    { products &&
+                        products.map((product, index)=>(
                             <SimpleItemPreview product={product} key={index} />
                         ))
                     }

--- a/components/Carousel.tsx
+++ b/components/Carousel.tsx
@@ -110,26 +110,7 @@ const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(
                 }
             }, 25);
         }
-/*
-const CarouselElement = React.forwardRef<HTMLDivElement, CarouselProps>(function CarouselElement(inProps, ref) {
-    const props = useThemeProps({ props: inProps, name: 'CarouselElement' });
-    const { children, carouselID, products, title, ...other } = props;
-*/
 
-/*
-    function slide(interval: number) {
-        const container = document.getElementById(carouselID);
-        if (!container) return;
-        let scrollCompleted = 0;
-        const slideInterval = setInterval(() => {
-            container.scrollLeft += interval;
-            scrollCompleted += 10;
-            if (scrollCompleted >= 100) {
-                clearInterval(slideInterval);
-            }
-        }, 25);
-    }
-*/
 return products.length > 0?(
     <CarouselComponentWrapper>
         <Typography color="#114FA3" variant="h4" mt={2} sx={{fontWeight: 900}}>{title}</Typography>
@@ -192,9 +173,11 @@ export function Carousel({ carouselID, products, title }: { carouselID: string; 
         <Stack direction="row" spacing={2} sx={{ width: '100%' }}>
             <ThemeProvider theme={theme}>
                 <CarouselElement carouselID={carouselID} products={products} title={title}>
-                    {products.map((product, index) => (
-                        <SimpleItemPreview key={index} product={product} />
-                    ))}
+                { products &&
+                        products.map((product, index)=>(
+                            <SimpleItemPreview product={product} key={index}/>
+                        ))
+                    }
                 </CarouselElement>
             </ThemeProvider>
         </Stack>


### PR DESCRIPTION
<!-- Please use the following format for the title:-->
<!-- <repo>_<sprint#>_<issue#>_<PR-title> -->

<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:**  Issue #637 (Bugfix: Homepage -- Make components match the width of the window)

- **Summary:** (Briefly describe what this PR does)
This PR fixes issue #637. "New Arrivals", "Recent Womenswear" and "Recent Menswear" overflows the width of the page when there are multiple items. I have managed to stop the overflow and allow the Carousel elements (arrows) to still appear when you re-size the window and still function as intended. The components of the page will match the width of the window.

- **Changes:**

Changes made to Carousel.tsx
- Added a ResponsiveWrapper that will keep the maxWidth at 1200, so that the page will look the same and the Carousel arrows will not disappear/overflow and will remain functional even after the browser window is resized.
- Changed width to '100%' for the CarouselComponentWrapper, instead
of 'fit-content'
- Changed width to '100%' for the CarouselContainerWrapper, instead of 
fit-content.
- Changed overflowx from 'scroll' to 'auto' in CarouselContainer.
- Changed maxWidth from '1200' to '100%' in CarouselContainer.
- Added a zIndex: '2' to CarouselArrowLeft and CarouselArrowRight (this is to 
ensure that the Carousel arrows will always stay above the content and will still work)
- Added "sx={{ width: '100%,  justifyContent: 'center' }} " to the <Stack> element.
- Added a "textAlign: 'center'" to the Typography.


## Screenshots / Visual Aids 🔎

This is how the homepage looks with zero products in the database.
![zero_products_screenshot](https://github.com/user-attachments/assets/07c340ac-cc2b-4e21-a4c7-03c5506b92be)


This is how the homepage looks when you have multiple products in the database (enough to cause an overflow).
![full_products_screenshot (1)](https://github.com/user-attachments/assets/571d5afc-b8a7-4e4f-a654-2ea94b2ad783)
![full_products_screenshot (2)](https://github.com/user-attachments/assets/caabc24a-d5d6-48ce-845e-211ce2ad619a)

This is how it looks when the browser has been resized.
![browser-resize-screenshot(1)](https://github.com/user-attachments/assets/e99f0277-35f7-4a59-ae26-7b847991acfd)
![browser-resize-screenshot(2)](https://github.com/user-attachments/assets/9d63c4c2-0ffe-477a-a1fe-f4ef26fa437d)

https://github.com/user-attachments/assets/e3126785-78c8-40f2-8581-3a5ad874decb


https://github.com/user-attachments/assets/88bc67fd-bb83-4d4a-a94e-a22e0f0333c8



<details>
  So what I have done is changed the width for the the Carousel elements from 'fit-content' to '100%'. This allows the Carousel elements and the product slide show to adjust according to the size of the browser window. This fixes the overflow issue. I also created a ResponsiveWrapper, this is a wrapper that will go around the CarouselComponentWrapper. It sets the width to '100%', but has a maxWidth of '1200'. This allows "New Arrivals", "Recent Womenswear" and "Recent Menswear" to remain centered and have a maximum width of 1200, just like "Popular Categories".
![code-snippet](https://github.com/user-attachments/assets/6d76bd7e-920c-4b7c-bc04-6bb4dfc231d8)


I have also added a zIndex '2' to the left and right Carousel arrows. This will allow the arrows to always remain on top of the components so that they are clickable and usable. I found that if I used 'overflow: hidden' without the zIndex, the arrows would either disappear or blend into the background and become unusable.
</details>


## How to Test 🧪
1. Run "npm start" on Belinda's Closet NestJS first.
2. Make sure that you are on branch (637-bugfix-homepage----make-components-match-the-width-of-the-window)
3. Run "npm run dev" on Belinda's Closet 
4. Add at least 10-15 products to your page. Make sure you are signed-in to an Admin account so that you can add products.
5. Re-size the browser window and make sure the components do not overflow and that the Carousel Arrows still work.


## Checklist ✅

- [X] I have **tested** this PR **locally** and it works as expected.
- [X] This PR **resolves an issue** (`Resolves #issue-number`).
- [X] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [X] **Squash commits** and enable **auto-merge** if approved.

