### PR TITLE
belindas-closet-nextjs_21_646_sidebar-component-conditioned

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,49 +1,62 @@
 "use client";
+
 import { useState } from "react";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import { Box, List, ListItem, ListItemText, IconButton, Drawer, useTheme, useMediaQuery, Typography } from "@mui/material";
 import MenuIcon from '@mui/icons-material/Menu';
+import useAuth from "@/hooks/useAuth";
 
 const Sidebar = () => {
   const pathname = usePathname();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
   const [mobileOpen, setMobileOpen] = useState(false);
 
-  const menuItems = [
-      { text: "Profile", href: "/profile" },
-      { text: "Products", href: "/add-product-page" },
-      { text: "User Management", href: "/edit-user-role-page" },
-  ];
+   const { isAuth, user } = useAuth();
+
+    if (!isAuth || user?.role === "user") {
+    return null;
+  }
 
   const handleDrawerToggle = () => {
     setMobileOpen(!mobileOpen);
   };
 
+  const menuItems = [
+    { text: "Profile", href: "/profile", roles: ["admin", "creator"] }, 
+    { text: "Products", href: "/add-product-page", roles: ["admin", "creator"] },
+    { text: "User Management", href: "/edit-user-role-page", roles: ["admin"] }, 
+    { text: "Dashboard", href: "/dashboard", roles:["admin", "creator"] }, 
+  ];
+
   const menuContent = (
     <List>
-      {menuItems.map((item) => (
-        <ListItem
-          key={item.text}
-          component={Link}
-          href={item.href}
-          onClick={() => isMobile && setMobileOpen(false)}
-          sx={{
-            backgroundColor: pathname === item.href ? 
-              theme.palette.action.selected : 
-              "transparent",
-            "&:hover": {
-              backgroundColor: theme.palette.action.hover,
-            },
-            textDecoration: "none",
-            color: theme.palette.text.primary,
-            marginBottom: "1rem"
-          }}
-        >
-          <ListItemText primary={item.text} />
-        </ListItem>
-      ))}
+      {menuItems
+        .filter(item => 
+          isAuth && user && item.roles.includes(user.role)
+        )
+        .map(item => (
+          <ListItem
+            key={item.text}
+            component={Link}
+            href={item.href}
+            onClick={() => isMobile && setMobileOpen(false)}
+            sx={{
+              backgroundColor: pathname === item.href
+                ? theme.palette.action.selected
+                : "transparent",
+              "&:hover": {
+                backgroundColor: theme.palette.action.hover,
+              },
+              textDecoration: "none",
+              color: theme.palette.text.primary,
+              marginBottom: "1rem",
+            }}
+          >
+            <ListItemText primary={item.text} />
+          </ListItem>
+        ))}
     </List>
   );
 
@@ -52,15 +65,15 @@ const Sidebar = () => {
       <>
         <Box
           sx={{
-            position: 'fixed',
-            top: '4rem',
+            position: "fixed",
+            top: "4rem",
             left: 0,
             right: 0,
-            height: '3rem',
+            height: "3rem",
             backgroundColor: theme.palette.background.paper,
             borderBottom: `1px solid ${theme.palette.divider}`,
-            display: 'flex',
-            alignItems: 'center',
+            display: "flex",
+            alignItems: "center",
             px: 2,
             zIndex: 1100,
             gap: 2,
@@ -72,23 +85,23 @@ const Sidebar = () => {
             edge="start"
             onClick={handleDrawerToggle}
             sx={{
-              '&:hover': {
+              "&:hover": {
                 backgroundColor: theme.palette.action.hover,
               },
             }}
           >
             <MenuIcon />
           </IconButton>
-          <Typography 
-            variant="subtitle1" 
+          <Typography
+            variant="subtitle1"
             component="div"
-            sx={{ 
+            sx={{
               fontWeight: 500,
               color: theme.palette.text.primary,
               flexGrow: 1,
             }}
           >
-            Admin options
+            Admin Options
           </Typography>
         </Box>
         <Drawer
@@ -100,10 +113,10 @@ const Sidebar = () => {
             keepMounted: true,
           }}
           sx={{
-            '& .MuiDrawer-paper': {
+            "& .MuiDrawer-paper": {
               width: 250,
-              mt: '7rem',
-              height: 'calc(100% - 7rem)',
+              mt: "7rem",
+              height: "calc(100% - 7rem)",
               backgroundColor: theme.palette.background.paper,
               borderRight: `1px solid ${theme.palette.divider}`,
             },
@@ -130,4 +143,4 @@ const Sidebar = () => {
   );
 };
 
-export default Sidebar; 
+export default Sidebar;


### PR DESCRIPTION
<!-- Please use the following format for the title:-->
<!-- <repo>_<sprint#>_<issue#>_<PR-title> -->

<!-- Example: appdev-repo_88_888_example-pr-name -->

<!-- Please fill out the following: -->
## Summary & Changes 📃
- **Resolves:** `#646`

- **Summary:** (Briefly describe what this PR does)
  - Limit rendering for sidebar component
  - When go to profile page under:
     - admin: can see all the links.
     - creator: can see all links excepts User Managements.
     - standard user: cannot see sidebar.
  - IMPORTANT: Before testing this, please import sidebar component into profile page too see this feature. 

## Screenshots / Visual Aids 🔎

https://github.com/user-attachments/assets/f133100b-373e-4a3f-8879-baca21047805




## How to Test 🧪
1. **Steps to Reproduce:**
   - Step 1: Switch onto this branch
   - Step 2: manually import sidebar component onto profile page (it takes two lines: `import Sidebar from "@/components/Sidebar";` and `<Sidebar></Sidebar>`)
2. **Expected Behavior:** When logged in under 3 types of users, you should see the sidebar being rendered differently.
3. **Actual Behavior (if bug):** None.


## Checklist ✅

- [x] I have **tested** this PR **locally** and it works as expected.
- [x] This PR **resolves an issue** (`Resolves #issue-number`).
- [x] **Reviewers, assignees(self), tags, and labels** are correctly assigned. <!-- on the menu to the right -->
- [x] **Squash commits** and enable **auto-merge** if approved.

